### PR TITLE
torcx: add a torcx-generator multicall alias

### DIFF
--- a/cli/torcx.go
+++ b/cli/torcx.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"github.com/Sirupsen/logrus"
+	"github.com/coreos/torcx/pkg/multicall"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -26,12 +27,20 @@ type GlobalCfg struct {
 }
 
 var (
-	// TorcxCmd is the top-level cobra command for torcx
+	// TorcxCmd is the top-level cobra command for `torcx`
 	TorcxCmd = &cobra.Command{
 		Use:           "torcx",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+
+	// TorcxGenCmd is the top-level cobra command for `torcx-generator`
+	TorcxGenCmd = &cobra.Command{
+		Use:          "torcx-generator",
+		RunE:         runApply,
+		SilenceUsage: true,
+	}
+
 	// TorcxCliCfg holds global CLI status available to all subcommands
 	TorcxCliCfg GlobalCfg
 )
@@ -45,6 +54,9 @@ func Init() error {
 
 	verboseFlag := TorcxCmd.PersistentFlags().VarPF((*cliCfgVerbose)(&TorcxCliCfg), "verbose", "v", "verbosity level")
 	verboseFlag.NoOptDefVal = "info"
+
+	multicall.AddCobra(TorcxCmd.Use, TorcxCmd)
+	multicall.AddCobra(TorcxGenCmd.Use, TorcxGenCmd)
 
 	return nil
 }

--- a/pkg/multicall/multicall.go
+++ b/pkg/multicall/multicall.go
@@ -1,0 +1,93 @@
+// Copyright 2015 The rkt Authors
+// Copyright 2017 CoreOS Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+// Package multicall provides facilities to build a binary which
+// behaves in different ways depending on how it has been invoked.
+// It integrates directly with cobra, supporting CLI binaries
+// with sub-commands.
+package multicall
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/spf13/cobra"
+)
+
+var commands = make(map[string]*cobra.Command)
+
+// AddCobra adds a new multicall name backed by a cobra command.
+// `name` is the command name and `cmd` is the cobra command that
+// will be executed for the specified named command.
+func AddCobra(name string, cmd *cobra.Command) error {
+	if name == "" {
+		return fmt.Errorf("empty multicall name provided")
+	}
+
+	if cmd == nil {
+		return fmt.Errorf("invalid multicall function provided")
+	}
+
+	if _, ok := commands[name]; ok {
+		return fmt.Errorf("command with name %q already exists", name)
+	}
+
+	commands[name] = cmd
+	return nil
+}
+
+// switchMulticall returns the cobra command corresponding to multicall binary `name`.
+func switchMulticall(name string) (*cobra.Command, error) {
+	if name == "" {
+		return nil, fmt.Errorf("empty multicall name provided")
+	}
+
+	cmd, ok := commands[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown multicall name %q", name)
+	}
+
+	return cmd, nil
+}
+
+// getName returns base name of the process executable, optionally
+// trying to resolve links.
+func getName(followLinks bool) string {
+	name := os.Args[0]
+
+	if followLinks {
+		exePath, err := os.Readlink("/proc/self/exe")
+		if err == nil {
+			name = exePath
+		}
+	}
+
+	return path.Base(name)
+}
+
+// MultiExecute dispatches execution based on binary name, optionally
+// resolving links.
+func MultiExecute(followLinks bool) error {
+	cliName := getName(followLinks)
+	cmd, err := switchMulticall(cliName)
+	if err != nil {
+		return err
+	}
+
+	return cmd.Execute()
+}

--- a/pkg/tar/untar.go
+++ b/pkg/tar/untar.go
@@ -129,9 +129,8 @@ func extractOne(hdr *tar.Header, r io.Reader, targetDir string, cfg ExtractCfg) 
 		if !cfg.Symlink {
 			return nil
 		}
-		if err := os.Symlink(hdr.Linkname, path); err != nil {
-			return err
-		}
+		// Skip adjusting metadata below for symlinks
+		return os.Symlink(hdr.Linkname, path)
 	case tar.TypeDir:
 		if err := os.MkdirAll(path, fi.Mode()); err != nil {
 			return err

--- a/torcx.go
+++ b/torcx.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"github.com/coreos/torcx/cli"
+	"github.com/coreos/torcx/pkg/multicall"
 )
 
 func main() {
@@ -34,16 +35,9 @@ func main() {
 }
 
 func run() error {
-	var err error
-
-	err = cli.Init()
-	if err != nil {
-		return err
-	}
-	err = cli.TorcxCmd.Execute()
-	if err != nil {
+	if err := cli.Init(); err != nil {
 		return err
 	}
 
-	return nil
+	return multicall.MultiExecute(false)
 }


### PR DESCRIPTION
This adds initial CLI support for a systemd generator called `torcx-generator`, via multicall argv[0] switch (aliased to `torcx apply`).
It introduces a multicall package based on rkt one, but with direct cobra support and optional proc self-exe symlink following.