### PR TITLE
cli/profile/use-image: check for correct input parameter

### DIFF
--- a/cli/profile_use_image.go
+++ b/cli/profile_use_image.go
@@ -54,7 +54,8 @@ func runProfileUse(cmd *cobra.Command, args []string) error {
 		return cmd.Usage()
 	}
 
-	imstr := strings.SplitN(args[0], ":", 2)
+	imgPair := args[0]
+	imstr := strings.SplitN(imgPair, ":", 2)
 	if len(imstr) != 2 {
 		return cmd.Usage()
 	}
@@ -101,7 +102,7 @@ func runProfileUse(cmd *cobra.Command, args []string) error {
 			}).Warn("Image does not exist, continuing")
 		} else {
 			return fmt.Errorf("Image %s does not exist, quitting. "+
-				"(pass --allow=missing to force)", args[1])
+				"(pass --allow=missing to force)", imgPair)
 		}
 	}
 


### PR DESCRIPTION
When running `"torcx profile use-image"` with an unknown image name, it panics with an error `"index out of range"`, since args[1] is missing.
Fix it by setting a variable imgPair correctly.