### PR TITLE
scripts/build: disable cgo for torcx binary

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,6 +35,7 @@ if [ -n "${BUILDTAGS}" ]; then
 fi
 
 export GOARCH="${ARCH}"
+export CGO_ENABLED=0
 
 go install                                                         \
     -installsuffix "static"                                        \


### PR DESCRIPTION
CGO should be disabled for torcx binary file, unless there are sufficient reasons for enabling CGO. As both libgpgme and fsnotify are not necessarily needed, we can safely disable CGO.

Fixes https://github.com/coreos/torcx/issues/26