### PR TITLE
paths: move rundir under /run

### DIFF
--- a/Documentation/design/paths.md
+++ b/Documentation/design/paths.md
@@ -8,13 +8,13 @@ Hardcoded:
 
 Configurable via environmental flags:
 * `$TORCX_BASEDIR`: `/var/lib/torcx/`
-* `$TORCX_RUNDIR`: `/var/run/torcx/`
+* `$TORCX_RUNDIR`: `/run/torcx/`
 * `$TORCX_CONFDIR`: `/etc/torcx/`
 
 Derived from configurables (shown with defaults):
-* BinDir: RunDir + `bin/` (`/var/run/torcx/bin/`)
-* UnpackDir: RunDir + `unpack/` (`/var/run/torcx/unpack/`)
-* RunProfile: RunDir + `profile.json` (`/var/run/torcx/profile.json`)
+* BinDir: RunDir + `bin/` (`/run/torcx/bin/`)
+* UnpackDir: RunDir + `unpack/` (`/run/torcx/unpack/`)
+* RunProfile: RunDir + `profile.json` (`/run/torcx/profile.json`)
 * NextProfile: ConfDir + `next-profile` (`/etc/torcx/next-profile`)
 * StoreDir:
   * (vendor) VendorDir + `store/` (`/usr/share/torcx/store/`)
@@ -36,6 +36,6 @@ Derived from configurables (shown with defaults):
 # Seal file content
 
 * `TORCX_PROFILE_NAME`: name of current running profile (default `vendor`)
-* `TORCX_PROFILE_PATH`: path of current running profile (default `/var/run/torcx/profile.json`)
-* `TORCX_BINDIR`: current overlay with binaries, for `$PATH` usage (default `/var/run/torcx/bin/`)
-* `TORCX_UNPACKDIR`: current root of the unpacked tree (default `/var/run/torcx/unpack/`)
+* `TORCX_PROFILE_PATH`: path of current running profile (default `/run/torcx/profile.json`)
+* `TORCX_BINDIR`: current overlay with binaries, for `$PATH` usage (default `/run/torcx/bin/`)
+* `TORCX_UNPACKDIR`: current root of the unpacked tree (default `/run/torcx/unpack/`)

--- a/cli/common.go
+++ b/cli/common.go
@@ -35,7 +35,7 @@ func fillCommonRuntime() (*torcx.CommonConfig, error) {
 
 	rundir := viper.GetString("rundir")
 	if rundir == "" {
-		rundir = "/var/run/torcx"
+		rundir = torcx.RunDir
 	}
 	if !filepath.IsAbs(rundir) {
 		return nil, errors.New("non-absolute rundir")

--- a/pkg/torcx/paths.go
+++ b/pkg/torcx/paths.go
@@ -19,6 +19,11 @@ import (
 	"path/filepath"
 )
 
+const (
+	// RunDir is the default path where torcx unpacks/propagates all runtime assets.
+	RunDir = "/run/torcx/"
+)
+
 // RunUnpackDir is the directory where root filesystems are unpacked.
 func (cc *CommonConfig) RunUnpackDir() string {
 	return filepath.Join(cc.RunDir, "unpack")


### PR DESCRIPTION
This moves torcx rundir from `/var/run/torcx/` to `/run/torcx/`.
Such a change should not have any impact on vanilla systems (where
`/var/run` is a symlink to `/run`), but adds future-proofing to
avoid issues in case of later mounts over `/var`.