### PR TITLE
cli/common: introduce a common config file

### DIFF
--- a/Documentation/schemas/torcx-config-v0.md
+++ b/Documentation/schemas/torcx-config-v0.md
@@ -1,0 +1,28 @@
+# torcx Config - v0
+
+torcx common config is a JSON data structure that can be optionally provided by an external party (e.g. an user) to influence torcx behavior.
+It is typically stored under `/etc/torcx/config.json`, but a custom path can be specified with a `torcx_config=` setting at kernel command-line.
+
+## Schema
+
+- kind (string, required)
+- value (object, required)
+  - base_dir (string, optional)
+  - conf_dir (string, optional)
+  - run_dir (string, optional)
+  - store_paths (array of string, optional)
+
+## Entries
+
+- kind: hardcoded to `torcx-config-v0` for this schema revision.
+  The type+version of this JSON manifest.
+- value: object containing a single typed key-value.
+  Config content.
+- value/base_dir: optional string.
+  Custom path to override base directory.
+- value/conf_dir: optional string.
+  Custom path to override config directory.
+- value/run_dir: optional string.
+  Custom path to override runtime directory.
+- value/store_paths: optional array of strings.
+  A list of store paths to add to the lookup paths.

--- a/pkg/torcx/config.go
+++ b/pkg/torcx/config.go
@@ -1,0 +1,121 @@
+// Copyright 2017 CoreOS Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package torcx
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+)
+
+// ValidateCommonConfig performs validation on torcx common config
+func ValidateCommonConfig(commonCfg *CommonConfig) error {
+	if commonCfg == nil {
+		return errors.New("nil common config")
+	}
+	if !filepath.IsAbs(commonCfg.BaseDir) {
+		return errors.Errorf("non-absolute base_dir %q", commonCfg.BaseDir)
+	}
+	if !filepath.IsAbs(commonCfg.RunDir) {
+		return errors.Errorf("non-absolute run_dir %q", commonCfg.RunDir)
+	}
+	if !filepath.IsAbs(commonCfg.ConfDir) {
+		return errors.Errorf("non-absolute conf_dir %q", commonCfg.ConfDir)
+	}
+	for _, p := range commonCfg.StorePaths {
+		if !filepath.IsAbs(p) {
+			return errors.Errorf("non absolute store path %q", p)
+		}
+	}
+
+	return nil
+}
+
+// ReadCommonConfig populates common config entries from optional settings from a config file
+func ReadCommonConfig(cfgPath string, commonCfg *CommonConfig) error {
+	if cfgPath == "" {
+		// No config file, skip this
+		return nil
+	}
+	if commonCfg == nil {
+		return errors.New("nil common configuration")
+	}
+
+	fp, err := os.Open(cfgPath)
+	if err != nil {
+		// Missing config file, skip this
+		return nil
+	}
+	defer fp.Close()
+	fileCfg := ConfigV0{}
+	if err := json.NewDecoder(bufio.NewReader(fp)).Decode(&fileCfg); err != nil {
+		return err
+	}
+	if fileCfg.Kind != CommonConfigV0K {
+		return errors.Errorf("unknown config file kind %q", fileCfg.Kind)
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"path": cfgPath,
+	}).Debug("common config file read")
+
+	// Populate with non-empty settings
+	if fileCfg.Value.BaseDir != "" {
+		commonCfg.BaseDir = fileCfg.Value.BaseDir
+	}
+	if fileCfg.Value.RunDir != "" {
+		commonCfg.RunDir = fileCfg.Value.RunDir
+	}
+	if fileCfg.Value.ConfDir != "" {
+		commonCfg.ConfDir = fileCfg.Value.ConfDir
+	}
+	if len(fileCfg.Value.StorePaths) > 0 {
+		commonCfg.StorePaths = append(commonCfg.StorePaths, fileCfg.Value.StorePaths...)
+	}
+
+	return nil
+}
+
+// RuntimeConfigPath determines runtime location of torcx common configuration file.
+func RuntimeConfigPath() string {
+	cfgPath, err := procConfigPath()
+	if err != nil {
+		cfgPath = defaultCfgPath
+	}
+	return cfgPath
+}
+
+// procConfigPath parses `/proc/cmdline` looking for a `torcx_config=` boot-time option.
+func procConfigPath() (string, error) {
+	configKey := "torcx_config="
+
+	bytes, err := ioutil.ReadFile("/proc/cmdline")
+	if err != nil {
+		return "", err
+	}
+	for _, token := range strings.Fields(string(bytes)) {
+		if strings.HasPrefix(token, configKey) {
+			return strings.TrimPrefix(token, configKey), nil
+		}
+	}
+
+	return "", errors.New("no custom torcx_config setting")
+}

--- a/pkg/torcx/paths.go
+++ b/pkg/torcx/paths.go
@@ -20,8 +20,17 @@ import (
 )
 
 const (
-	// RunDir is the default path where torcx unpacks/propagates all runtime assets.
-	RunDir = "/run/torcx/"
+	// DefaultRunDir is the default path where torcx unpacks/propagates all runtime assets.
+	DefaultRunDir = "/run/torcx/"
+	// DefaultBaseDir is the default torcx base directory
+	DefaultBaseDir = "/var/lib/torcx/"
+	// DefaultConfDir is the default torcx config directory
+	DefaultConfDir = "/etc/torcx/"
+	// VendorStorePath is the vendor store path
+	VendorStorePath = VENDOR_DIR + "/store/"
+
+	// defaultCfgPath is the default path for common torcx config
+	defaultCfgPath = "/etc/torcx/config.json"
 )
 
 // RunUnpackDir is the directory where root filesystems are unpacked.

--- a/pkg/torcx/types.go
+++ b/pkg/torcx/types.go
@@ -35,15 +35,23 @@ const (
 	DefaultTagRef = "com.coreos.cl"
 	// DEFAULT_PROFILE_NAME is the default profile name used
 	DEFAULT_PROFILE_NAME = "vendor"
+	// CommonConfigV0K - common torcx config kind, v0
+	CommonConfigV0K = "torcx-config-v0"
 )
+
+// ConfigV0 holds common torcx configuration in JSON format
+type ConfigV0 struct {
+	Kind  string       `json:"kind"`
+	Value CommonConfig `json:"value"`
+}
 
 // CommonConfig contains runtime configuration items common to all
 // torcx subcommands
 type CommonConfig struct {
-	BaseDir    string
-	RunDir     string
-	ConfDir    string
-	StorePaths []string
+	BaseDir    string   `json:"base_dir,omitempty"`
+	RunDir     string   `json:"run_dir,omitempty"`
+	ConfDir    string   `json:"conf_dir,omitempty"`
+	StorePaths []string `json:"store_paths,omitempty"`
 }
 
 // ApplyConfig contains runtime configuration items specific to


### PR DESCRIPTION
This introduces a `torcx-config-v0` JSON input to specify common
torcx configuration. This is mostly useful for torcx-generator, as
it can't be passed custom command-line or environmental flags.

The config file is located by default under `/etc/torcx/config.json`
but can be moved somewhere else by specifying `torcx_config=` as a
kernel boot option.