### PR TITLE
profile: introduce upper and lower profiles

### DIFF
--- a/Documentation/design/paths.md
+++ b/Documentation/design/paths.md
@@ -5,6 +5,7 @@ Paths reserved for `torcx` usage.
 Hardcoded:
 * SealFile: `/run/metadata/torcx`
 * VendorDir: `/usr/share/torcx/`
+* OemDir: `/usr/share/oem/torcx/`
 
 Configurable via environmental flags:
 * `$TORCX_BASEDIR`: `/var/lib/torcx/`
@@ -18,6 +19,7 @@ Derived from configurables (shown with defaults):
 * NextProfile: ConfDir + `next-profile` (`/etc/torcx/next-profile`)
 * StoreDir:
   * (vendor) VendorDir + `store/` (`/usr/share/torcx/store/`)
+  * (oem) OemDir + `store/` (`/usr/share/oem/torcx/store`)
   * (user) BaseDir + `store/` (`/var/lib/torcx/store/`)
   * (runtime) `$TORCX_STOREPATH`
 * AuthDir: 
@@ -25,6 +27,7 @@ Derived from configurables (shown with defaults):
   * (user) ConfDir + `auth.d/` (`/etc/torcx/auth.d/`)
 * ProfileDir:
   * (vendor) VendorDir + `profiles/` (`/usr/share/torcx/profiles/`)
+  * (oem) OemDir + `profiles/` (`/usr/share/oem/torcx/profiles/`)
   * (user) ConfDir + `profiles/` (`/etc/torcx/profiles/`)
 
 # Paths from environmental flags
@@ -35,8 +38,8 @@ Derived from configurables (shown with defaults):
 
 # Seal file content
 
-* `TORCX_VENDOR_PROFILE`: name of the base vendor profile (default `vendor`)
-* `TORCX_USER_PROFILE`: name of current running user profile (default ``)
+* `TORCX_LOWER_PROFILES`: array of names of lower vendor/oem profiles, separated by `:` (default `vendor:oem`)
+* `TORCX_UPPER_PROFILE`: name of current running user profile (default ``)
 * `TORCX_PROFILE_PATH`: path of current running profile (default `/run/torcx/profile.json`)
 * `TORCX_BINDIR`: current overlay with binaries, for `$PATH` usage (default `/run/torcx/bin/`)
 * `TORCX_UNPACKDIR`: current root of the unpacked tree (default `/run/torcx/unpack/`)

--- a/Documentation/design/paths.md
+++ b/Documentation/design/paths.md
@@ -35,7 +35,8 @@ Derived from configurables (shown with defaults):
 
 # Seal file content
 
-* `TORCX_PROFILE_NAME`: name of current running profile (default `vendor`)
+* `TORCX_VENDOR_PROFILE`: name of the base vendor profile (default `vendor`)
+* `TORCX_USER_PROFILE`: name of current running user profile (default ``)
 * `TORCX_PROFILE_PATH`: path of current running profile (default `/run/torcx/profile.json`)
 * `TORCX_BINDIR`: current overlay with binaries, for `$PATH` usage (default `/run/torcx/bin/`)
 * `TORCX_UNPACKDIR`: current root of the unpacked tree (default `/run/torcx/unpack/`)

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -66,19 +66,24 @@ func runApply(cmd *cobra.Command, args []string) error {
 // fillApplyRuntime generate runtime config for apply subcommand starting from
 // system-wide configuration
 func fillApplyRuntime(commonCfg *torcx.CommonConfig) (*torcx.ApplyConfig, error) {
+	var userProfileName, vendorProfileName string
+
+	vendorProfileName = torcx.VendorProfileName
 	// If we fail to read /etc/torcx/next-profile, report the error and use the default
-	profileName, err := commonCfg.NextProfileName()
+	userProfileName, err := commonCfg.NextProfileName()
 	if err != nil {
-		logrus.Warn("Falling back to default profile:", err)
-		profileName = torcx.DEFAULT_PROFILE_NAME
+		logrus.Warnf("no next profile: %s", err)
+		userProfileName = ""
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"profile": profileName,
+		"vendor profile (lower)": vendorProfileName,
+		"user profile (upper)":   userProfileName,
 	}).Debug("apply configuration parsed")
 
 	return &torcx.ApplyConfig{
 		CommonConfig: *commonCfg,
-		Profile:      profileName,
+		LowerProfile: vendorProfileName,
+		UpperProfile: userProfileName,
 	}, nil
 }

--- a/cli/common.go
+++ b/cli/common.go
@@ -34,6 +34,7 @@ func fillCommonRuntime() (*torcx.CommonConfig, error) {
 		ConfDir: torcx.DefaultConfDir,
 		StorePaths: []string{
 			torcx.VendorStoreDir,
+			torcx.OemStoreDir,
 		},
 	}
 

--- a/cli/common.go
+++ b/cli/common.go
@@ -33,7 +33,7 @@ func fillCommonRuntime() (*torcx.CommonConfig, error) {
 		RunDir:  torcx.DefaultRunDir,
 		ConfDir: torcx.DefaultConfDir,
 		StorePaths: []string{
-			torcx.VendorStorePath,
+			torcx.VendorStoreDir,
 		},
 	}
 

--- a/cli/image_list.go
+++ b/cli/image_list.go
@@ -69,7 +69,7 @@ func runImageList(cmd *cobra.Command, args []string) error {
 	}
 
 	imageListOut := ImageList{
-		Kind:  TorcxImageListV0,
+		Kind:  TorcxImageListV0K,
 		Value: imgList,
 	}
 

--- a/cli/profile.go
+++ b/cli/profile.go
@@ -38,8 +38,8 @@ func init() {
 // starting from system-wide state and config
 func fillProfileRuntime(commonCfg *torcx.CommonConfig) (*torcx.ProfileConfig, error) {
 	var (
-		userProfileName   string
-		vendorProfileName string
+		lowerProfileNames []string
+		upperProfileName  string
 		curProfilePath    string
 		nextProfile       string
 	)
@@ -48,10 +48,10 @@ func fillProfileRuntime(commonCfg *torcx.CommonConfig) (*torcx.ProfileConfig, er
 		return nil, errors.New("missing common configuration")
 	}
 
-	upn, vpn, err := torcx.CurrentProfileNames()
+	upn, lpn, err := torcx.CurrentProfileNames()
 	if err == nil {
-		userProfileName = upn
-		vendorProfileName = vpn
+		lowerProfileNames = lpn
+		upperProfileName = upn
 	}
 	cpp, err := torcx.CurrentProfilePath()
 	if err == nil {
@@ -64,15 +64,15 @@ func fillProfileRuntime(commonCfg *torcx.CommonConfig) (*torcx.ProfileConfig, er
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"user profile":   userProfileName,
-		"vendor profile": vendorProfileName,
+		"lower profiles": lpn,
+		"upper profile":  upperProfileName,
 		"next profile":   nextProfile,
 	}).Debug("profile configuration parsed")
 
 	return &torcx.ProfileConfig{
 		CommonConfig:       *commonCfg,
-		UserProfileName:    userProfileName,
-		VendorProfileName:  vendorProfileName,
+		LowerProfileNames:  lowerProfileNames,
+		UserProfileName:    upperProfileName,
 		CurrentProfilePath: curProfilePath,
 		NextProfile:        nextProfile,
 	}, nil

--- a/cli/profile.go
+++ b/cli/profile.go
@@ -38,18 +38,20 @@ func init() {
 // starting from system-wide state and config
 func fillProfileRuntime(commonCfg *torcx.CommonConfig) (*torcx.ProfileConfig, error) {
 	var (
-		curProfileName string
-		curProfilePath string
-		nextProfile    string
+		userProfileName   string
+		vendorProfileName string
+		curProfilePath    string
+		nextProfile       string
 	)
 
 	if commonCfg == nil {
 		return nil, errors.New("missing common configuration")
 	}
 
-	cpn, err := torcx.CurrentProfileName()
+	upn, vpn, err := torcx.CurrentProfileNames()
 	if err == nil {
-		curProfileName = cpn
+		userProfileName = upn
+		vendorProfileName = vpn
 	}
 	cpp, err := torcx.CurrentProfilePath()
 	if err == nil {
@@ -58,18 +60,19 @@ func fillProfileRuntime(commonCfg *torcx.CommonConfig) (*torcx.ProfileConfig, er
 
 	nextProfile, err = commonCfg.NextProfileName()
 	if err != nil {
-		logrus.Warnf("cannot read %s: %v - using default", commonCfg.NextProfile(), err)
-		nextProfile = torcx.DEFAULT_PROFILE_NAME
+		nextProfile = ""
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"current profile": curProfileName,
-		"next profile":    nextProfile,
+		"user profile":   userProfileName,
+		"vendor profile": vendorProfileName,
+		"next profile":   nextProfile,
 	}).Debug("profile configuration parsed")
 
 	return &torcx.ProfileConfig{
 		CommonConfig:       *commonCfg,
-		CurrentProfileName: curProfileName,
+		UserProfileName:    userProfileName,
+		VendorProfileName:  vendorProfileName,
 		CurrentProfilePath: curProfilePath,
 		NextProfile:        nextProfile,
 	}, nil

--- a/cli/profile_check.go
+++ b/cli/profile_check.go
@@ -63,7 +63,7 @@ func runProfileCheck(cmd *cobra.Command, args []string) error {
 
 			logrus.Infof("No profile specified, using next profile %q", flagProfileCheckName)
 
-			if flagProfileCheckName == torcx.DEFAULT_PROFILE_NAME {
+			if flagProfileCheckName == torcx.VendorProfileName {
 				logrus.Warn("Checking default (%s) profile - do you mean to do that?", flagProfileCheckName)
 			}
 		}

--- a/cli/profile_list.go
+++ b/cli/profile_list.go
@@ -57,20 +57,27 @@ func runProfileList(cmd *cobra.Command, args []string) error {
 		profNames = append(profNames, k)
 	}
 
-	var curName, curPath *string
-	if profileCfg.CurrentProfileName != "" {
-		curName = &profileCfg.CurrentProfileName
+	var userName, vendorName, nextName, curPath *string
+	if profileCfg.UserProfileName != "" {
+		userName = &profileCfg.UserProfileName
+	}
+	if profileCfg.VendorProfileName != "" {
+		vendorName = &profileCfg.VendorProfileName
+	}
+	if profileCfg.NextProfile != "" {
+		nextName = &profileCfg.NextProfile
 	}
 	if profileCfg.CurrentProfilePath != "" {
 		curPath = &profileCfg.CurrentProfilePath
 	}
 
 	profListOut := ProfileList{
-		Kind: TorcxProfileListV0,
+		Kind: TorcxProfileListV0K,
 		Value: profileList{
-			CurrentProfileName: curName,
+			UserProfileName:    userName,
+			VendorProfileName:  vendorName,
 			CurrentProfilePath: curPath,
-			NextProfileName:    profileCfg.NextProfile,
+			NextProfileName:    nextName,
 			Profiles:           profNames,
 		},
 	}

--- a/cli/profile_list.go
+++ b/cli/profile_list.go
@@ -57,12 +57,13 @@ func runProfileList(cmd *cobra.Command, args []string) error {
 		profNames = append(profNames, k)
 	}
 
-	var userName, vendorName, nextName, curPath *string
+	var userName, nextName, curPath *string
+	lowerNames := []string{}
+	if len(profileCfg.LowerProfileNames) > 0 {
+		lowerNames = profileCfg.LowerProfileNames
+	}
 	if profileCfg.UserProfileName != "" {
 		userName = &profileCfg.UserProfileName
-	}
-	if profileCfg.VendorProfileName != "" {
-		vendorName = &profileCfg.VendorProfileName
 	}
 	if profileCfg.NextProfile != "" {
 		nextName = &profileCfg.NextProfile
@@ -74,8 +75,8 @@ func runProfileList(cmd *cobra.Command, args []string) error {
 	profListOut := ProfileList{
 		Kind: TorcxProfileListV0K,
 		Value: profileList{
+			LowerProfileNames:  lowerNames,
 			UserProfileName:    userName,
-			VendorProfileName:  vendorName,
 			CurrentProfilePath: curPath,
 			NextProfileName:    nextName,
 			Profiles:           profNames,

--- a/cli/types.go
+++ b/cli/types.go
@@ -28,8 +28,8 @@ type ProfileList struct {
 }
 
 type profileList struct {
+	LowerProfileNames  []string `json:"lower_profile_names"`
 	UserProfileName    *string  `json:"user_profile_name"`
-	VendorProfileName  *string  `json:"vendor_profile_name"`
 	CurrentProfilePath *string  `json:"current_profile_path"`
 	NextProfileName    *string  `json:"next_profile_name"`
 	Profiles           []string `json:"profiles"`

--- a/cli/types.go
+++ b/cli/types.go
@@ -17,8 +17,8 @@ package cli
 import "github.com/coreos/torcx/pkg/torcx"
 
 const (
-	// TorcxProfileListV0 is the JSON kind identifier for a profile list
-	TorcxProfileListV0 = "torcx-profile-list-v0"
+	// TorcxProfileListV0K is the JSON kind identifier for a profile list
+	TorcxProfileListV0K = "torcx-profile-list-v0"
 )
 
 // ProfileList is the JSON container for profile list output
@@ -28,14 +28,16 @@ type ProfileList struct {
 }
 
 type profileList struct {
-	CurrentProfileName *string  `json:"current_profile_name"`
+	UserProfileName    *string  `json:"user_profile_name"`
+	VendorProfileName  *string  `json:"vendor_profile_name"`
 	CurrentProfilePath *string  `json:"current_profile_path"`
-	NextProfileName    string   `json:"next_profile_name"`
+	NextProfileName    *string  `json:"next_profile_name"`
 	Profiles           []string `json:"profiles"`
 }
 
 const (
-	TorcxImageListV0 = "torcx-image-list-v0"
+	// TorcxImageListV0K is the JSON kind identifier for an image list
+	TorcxImageListV0K = "torcx-image-list-v0"
 )
 
 type ImageList struct {

--- a/ftests/generator_test.go
+++ b/ftests/generator_test.go
@@ -15,7 +15,6 @@
 package ftests
 
 import (
-	"os"
 	"os/exec"
 	"testing"
 )
@@ -28,14 +27,6 @@ func TestGeneratorEmpty(t *testing.T) {
 		RunTestInContainer(t, cfg)
 		return
 	}
-
-	// Prepare an empty vendor profile
-	_ = os.MkdirAll("/usr/share/torcx/profiles", 0755)
-	fp, err := os.Create("/usr/share/torcx/profiles/vendor.json")
-	if err != nil && !os.IsExist(err) {
-		t.Fatal(err)
-	}
-	fp.Close()
 
 	cmd := exec.Command("torcx-generator")
 	bytes, err := cmd.CombinedOutput()

--- a/ftests/rkt.go
+++ b/ftests/rkt.go
@@ -57,6 +57,7 @@ func RunTestInContainer(t *testing.T, cfg RktConfig) {
 	}
 	rktOpts := []string{
 		"--insecure-options=all",
+		"--net=none",
 		"run",
 	}
 	args := rktOpts

--- a/pkg/torcx/build_constants.go
+++ b/pkg/torcx/build_constants.go
@@ -22,6 +22,6 @@ const (
 	VendorDir = "/usr/share/torcx/"
 	// DefaultTagRef is the default image reference looked up in archives.
 	DefaultTagRef = "com.coreos.cl"
-	// VendorProfileName is the default profile name used
+	// VendorProfileName is the default profile name used.
 	VendorProfileName = "vendor"
 )

--- a/pkg/torcx/build_constants.go
+++ b/pkg/torcx/build_constants.go
@@ -20,8 +20,12 @@ const (
 	SealPath = "/run/metadata/torcx"
 	// VendorDir contains (immutable) assets provided by the vendor.
 	VendorDir = "/usr/share/torcx/"
+	// OemDir contains (mutable) assets provided by the oem.
+	OemDir = "/usr/share/oem/torcx/"
 	// DefaultTagRef is the default image reference looked up in archives.
 	DefaultTagRef = "com.coreos.cl"
-	// VendorProfileName is the default profile name used.
+	// VendorProfileName is the default vendor profile used.
 	VendorProfileName = "vendor"
+	// OemProfileName is the default oem profile used.
+	OemProfileName = "oem"
 )

--- a/pkg/torcx/build_constants.go
+++ b/pkg/torcx/build_constants.go
@@ -1,0 +1,27 @@
+// Copyright 2017 CoreOS Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package torcx
+
+// These are torcx constants that can be overridden via link arguments at build-time.
+const (
+	// SealPath is the path where metadata are written once the system has been sealed.
+	SealPath = "/run/metadata/torcx"
+	// VendorDir contains (immutable) assets provided by the vendor.
+	VendorDir = "/usr/share/torcx/"
+	// DefaultTagRef is the default image reference looked up in archives.
+	DefaultTagRef = "com.coreos.cl"
+	// VendorProfileName is the default profile name used
+	VendorProfileName = "vendor"
+)

--- a/pkg/torcx/paths.go
+++ b/pkg/torcx/paths.go
@@ -32,6 +32,11 @@ const (
 	// VendorProfilesDir is the vendor profiles path
 	VendorProfilesDir = VendorDir + "profiles/"
 
+	// OemStoreDir is the vendor store path
+	OemStoreDir = OemDir + "store/"
+	// OemProfilesDir is the vendor profiles path
+	OemProfilesDir = OemDir + "profiles/"
+
 	// defaultCfgPath is the default path for common torcx config
 	defaultCfgPath = DefaultConfDir + "config.json"
 )
@@ -49,7 +54,8 @@ func (cc *CommonConfig) RunBinDir() string {
 // ProfileDirs are the list of directories where we look for profiles.
 func (cc *CommonConfig) ProfileDirs() []string {
 	return []string{
-		filepath.Join(VendorDir, "profiles"),
+		VendorProfilesDir,
+		OemProfilesDir,
 		cc.UserProfileDir(),
 	}
 }

--- a/pkg/torcx/paths.go
+++ b/pkg/torcx/paths.go
@@ -26,11 +26,14 @@ const (
 	DefaultBaseDir = "/var/lib/torcx/"
 	// DefaultConfDir is the default torcx config directory
 	DefaultConfDir = "/etc/torcx/"
+
 	// VendorStorePath is the vendor store path
-	VendorStorePath = VENDOR_DIR + "/store/"
+	VendorStorePath = VendorDir + "store/"
+	// VendorProfile is the vendor (lower) profile
+	VendorProfile = VendorDir + VendorProfileName + ".json"
 
 	// defaultCfgPath is the default path for common torcx config
-	defaultCfgPath = "/etc/torcx/config.json"
+	defaultCfgPath = DefaultConfDir + "config.json"
 )
 
 // RunUnpackDir is the directory where root filesystems are unpacked.
@@ -46,7 +49,7 @@ func (cc *CommonConfig) RunBinDir() string {
 // ProfileDirs are the list of directories where we look for profiles.
 func (cc *CommonConfig) ProfileDirs() []string {
 	return []string{
-		filepath.Join(VENDOR_DIR, "profiles"),
+		filepath.Join(VendorDir, "profiles"),
 		cc.UserProfileDir(),
 	}
 }

--- a/pkg/torcx/paths.go
+++ b/pkg/torcx/paths.go
@@ -27,10 +27,10 @@ const (
 	// DefaultConfDir is the default torcx config directory
 	DefaultConfDir = "/etc/torcx/"
 
-	// VendorStorePath is the vendor store path
-	VendorStorePath = VendorDir + "store/"
-	// VendorProfile is the vendor (lower) profile
-	VendorProfile = VendorDir + VendorProfileName + ".json"
+	// VendorStoreDir is the vendor store path
+	VendorStoreDir = VendorDir + "store/"
+	// VendorProfilesDir is the vendor profiles path
+	VendorProfilesDir = VendorDir + "profiles/"
 
 	// defaultCfgPath is the default path for common torcx config
 	defaultCfgPath = DefaultConfDir + "config.json"

--- a/pkg/torcx/perform.go
+++ b/pkg/torcx/perform.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
@@ -207,8 +208,8 @@ func SealSystemState(applyCfg *ApplyConfig) error {
 	defer fp.Close()
 
 	content := []string{
-		fmt.Sprintf("%s=%q", SealVendorProfile, VendorProfileName),
-		fmt.Sprintf("%s=%q", SealUserProfile, applyCfg.UpperProfile),
+		fmt.Sprintf("%s=%q", SealLowerProfiles, strings.Join(applyCfg.LowerProfiles, ":")),
+		fmt.Sprintf("%s=%q", SealUpperProfile, applyCfg.UpperProfile),
 		fmt.Sprintf("%s=%q", SealRunProfilePath, applyCfg.RunProfile()),
 		fmt.Sprintf("%s=%q", SealBindir, applyCfg.RunBinDir()),
 		fmt.Sprintf("%s=%q", SealUnpackdir, applyCfg.RunUnpackDir()),

--- a/pkg/torcx/perform.go
+++ b/pkg/torcx/perform.go
@@ -197,14 +197,14 @@ func SealSystemState(applyCfg *ApplyConfig) error {
 		return errors.New("missing apply configuration")
 	}
 
-	dirname := filepath.Dir(FUSE_PATH)
+	dirname := filepath.Dir(SealPath)
 	if _, err := os.Stat(dirname); err != nil && os.IsNotExist(err) {
 		if err := os.MkdirAll(dirname, 0755); err != nil {
 			return err
 		}
 	}
 
-	fp, err := os.Create(FUSE_PATH)
+	fp, err := os.Create(SealPath)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func SealSystemState(applyCfg *ApplyConfig) error {
 	}
 
 	logrus.WithFields(logrus.Fields{
-		"path":    FUSE_PATH,
+		"path":    SealPath,
 		"content": content,
 	}).Debug("system state sealed")
 

--- a/pkg/torcx/perform.go
+++ b/pkg/torcx/perform.go
@@ -18,8 +18,8 @@ import (
 	"archive/tar"
 	"bufio"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -47,28 +47,49 @@ func ApplyProfile(applyCfg *ApplyConfig) error {
 		return errors.Wrap(err, "profile setup")
 	}
 
-	localProfiles, err := ListProfiles(applyCfg.ProfileDirs())
-	if err != nil {
-		return errors.Wrap(err, "profiles listing failed")
-	}
-
-	originPath, ok := localProfiles[applyCfg.Profile]
-	if !ok {
-		return fmt.Errorf("profile %q not found", applyCfg.Profile)
-	}
-
-	opp, err := os.Open(originPath)
+	images, err := mergeProfiles(applyCfg)
 	if err != nil {
 		return err
 	}
-	defer opp.Close()
+	if len(images.Images) > 0 {
+		if err := applyImages(applyCfg, images); err != nil {
+			return err
+		}
+	}
 
-	images, err := readProfileReader(bufio.NewReader(opp))
+	runProfile := ProfileManifestV0{
+		Kind:  ProfileManifestV0K,
+		Value: images,
+	}
+	rpp, err := os.Create(applyCfg.RunProfile())
 	if err != nil {
 		return err
 	}
-	if len(images.Images) == 0 {
-		return nil
+	defer rpp.Close()
+	bufwr := bufio.NewWriter(rpp)
+	defer bufwr.Flush()
+	enc := json.NewEncoder(bufwr)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(runProfile); err != nil {
+		return errors.Wrapf(err, "writing %q", applyCfg.RunProfile())
+	}
+
+	err = os.Chmod(applyCfg.RunProfile(), 0444)
+	if err != nil {
+		return err
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"upper profile":  applyCfg.UpperProfile,
+		"sealed profile": applyCfg.RunProfile(),
+	}).Debug("profile applied")
+	return nil
+}
+
+// applyImages unpacks and propagates assets from a list of images.
+func applyImages(applyCfg *ApplyConfig, images Images) error {
+	if applyCfg == nil {
+		return errors.New("missing apply configuration")
 	}
 
 	storeCache, err := NewStoreCache(applyCfg.StorePaths)
@@ -93,7 +114,6 @@ func ApplyProfile(applyCfg *ApplyConfig) error {
 			continue
 		}
 
-		// phase 1: unpack image
 		imageRoot, err := unpackTgz(applyCfg, tgzArchive.Filepath, im.Name)
 		if err != nil {
 			failedImages = append(failedImages, im)
@@ -103,7 +123,6 @@ func ApplyProfile(applyCfg *ApplyConfig) error {
 		logFields["path"] = imageRoot
 		logrus.WithFields(logFields).Debug("image unpacked")
 
-		// phase 2: propagate assets
 		assets, err := retrieveAssets(applyCfg, imageRoot)
 		if err != nil {
 			failedImages = append(failedImages, im)
@@ -164,29 +183,6 @@ func ApplyProfile(applyCfg *ApplyConfig) error {
 		return fmt.Errorf("failed to install %d images", len(failedImages))
 	}
 
-	// phase 3: record current profile
-	rpp, err := os.Create(applyCfg.RunProfile())
-	if err != nil {
-		return err
-	}
-	defer rpp.Close()
-	if n, err := opp.Seek(0, io.SeekStart); err != nil || n != 0 {
-		return fmt.Errorf("seek failed")
-	}
-	_, err = io.Copy(rpp, opp)
-	if err != nil {
-		return err
-	}
-	err = os.Chmod(applyCfg.RunProfile(), 0444)
-	if err != nil {
-		return err
-	}
-
-	logrus.WithFields(logrus.Fields{
-		"name":             applyCfg.Profile,
-		"original profile": originPath,
-		"sealed profile":   applyCfg.RunProfile(),
-	}).Debug("profile applied")
 	return nil
 }
 
@@ -211,10 +207,11 @@ func SealSystemState(applyCfg *ApplyConfig) error {
 	defer fp.Close()
 
 	content := []string{
-		fmt.Sprintf("%s=%q", FUSE_PROFILE_NAME, applyCfg.Profile),
-		fmt.Sprintf("%s=%q", FUSE_PROFILE_PATH, applyCfg.RunProfile()),
-		fmt.Sprintf("%s=%q", FUSE_BINDIR, applyCfg.RunBinDir()),
-		fmt.Sprintf("%s=%q", FUSE_UNPACKDIR, applyCfg.RunUnpackDir()),
+		fmt.Sprintf("%s=%q", SealVendorProfile, VendorProfileName),
+		fmt.Sprintf("%s=%q", SealUserProfile, applyCfg.UpperProfile),
+		fmt.Sprintf("%s=%q", SealRunProfilePath, applyCfg.RunProfile()),
+		fmt.Sprintf("%s=%q", SealBindir, applyCfg.RunBinDir()),
+		fmt.Sprintf("%s=%q", SealUnpackdir, applyCfg.RunUnpackDir()),
 	}
 
 	for _, line := range content {
@@ -263,19 +260,18 @@ func setupPaths(applyCfg *ApplyConfig) error {
 		}
 	}
 
-	// Now, mount a tmpfs directory to the unpack directory
-	// We need to do this because, unsurprisingly, "/run" is noexec
+	// Now, mount a tmpfs directory to the unpack directory.
+	// We need to do this because "/run" is typically marked "noexec".
 	if err := syscall.Mount("none", applyCfg.RunUnpackDir(), "tmpfs", 0, ""); err != nil {
 		return errors.Wrap(err, "failed to mount unpack dir")
 	}
-
-	logrus.WithField("target", applyCfg.RunUnpackDir()).Debug("mounted tmpfs")
 
 	// Default tmpfs permissions are 1777, which can trip up path auditing
 	if err := os.Chmod(applyCfg.RunUnpackDir(), 0755); err != nil {
 		return errors.Wrap(err, "failed to chmod unpack dir")
 	}
 
+	logrus.WithField("target", applyCfg.RunUnpackDir()).Debug("mounted tmpfs")
 	return nil
 }
 

--- a/pkg/torcx/profile.go
+++ b/pkg/torcx/profile.go
@@ -32,7 +32,7 @@ import (
 func CurrentProfileName() (string, error) {
 	var profile string
 
-	meta, err := ReadMetadata(FUSE_PATH)
+	meta, err := ReadMetadata(SealPath)
 	if err != nil {
 		return "", err
 	}
@@ -53,7 +53,7 @@ func CurrentProfileName() (string, error) {
 func CurrentProfilePath() (string, error) {
 	var path string
 
-	meta, err := ReadMetadata(FUSE_PATH)
+	meta, err := ReadMetadata(SealPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/torcx/types.go
+++ b/pkg/torcx/types.go
@@ -15,10 +15,10 @@
 package torcx
 
 const (
-	// SealUserProfile is the key label for user profile name
-	SealUserProfile = "TORCX_USER_PROFILE"
-	// SealVendorProfile is the key label for vendor profile path
-	SealVendorProfile = "TORCX_VENDOR_PROFILE"
+	// SealUpperProfile is the key label for user profile name
+	SealUpperProfile = "TORCX_UPPER_PROFILE"
+	// SealLowerProfiles is the key label for vendor profile path
+	SealLowerProfiles = "TORCX_LOWER_PROFILES"
 	// SealRunProfilePath is the key label for vendor profile path
 	SealRunProfilePath = "TORCX_PROFILE_PATH"
 	// SealBindir is the key label for seal bindir
@@ -52,16 +52,16 @@ type CommonConfig struct {
 // the `apply` subcommand
 type ApplyConfig struct {
 	CommonConfig
-	LowerProfile string
-	UpperProfile string
+	LowerProfiles []string
+	UpperProfile  string
 }
 
 // ProfileConfig contains runtime configuration items specific to
 // the `profile` subcommand
 type ProfileConfig struct {
 	CommonConfig
+	LowerProfileNames  []string
 	UserProfileName    string
-	VendorProfileName  string
 	CurrentProfilePath string
 	NextProfile        string
 }

--- a/pkg/torcx/types.go
+++ b/pkg/torcx/types.go
@@ -15,8 +15,6 @@
 package torcx
 
 const (
-	// FUSE_PATH is the hardcoded fuse location
-	FUSE_PATH = "/run/metadata/torcx"
 	// FUSE_PROFILE_NAME is the key label for fuse profile name
 	FUSE_PROFILE_NAME = "TORCX_PROFILE_NAME"
 	// FUSE_PROFILE_PATH is the key label for fuse profile path
@@ -25,16 +23,10 @@ const (
 	FUSE_BINDIR = "TORCX_BINDIR"
 	// FUSE_UNPACKDIR is the key label for fuse unpackdir
 	FUSE_UNPACKDIR = "TORCX_UNPACKDIR"
-	// VENDOR_DIR
-	VENDOR_DIR = "/usr/share/torcx"
 	// ProfileManifestV0K - profile manifest kind, v0
 	ProfileManifestV0K = "profile-manifest-v0"
 	// ImageManifestV0K - image manifest kind, v0
 	ImageManifestV0K = "image-manifest-v0"
-	// DefaultTagRef is the default image reference looked up in archives
-	DefaultTagRef = "com.coreos.cl"
-	// DEFAULT_PROFILE_NAME is the default profile name used
-	DEFAULT_PROFILE_NAME = "vendor"
 	// CommonConfigV0K - common torcx config kind, v0
 	CommonConfigV0K = "torcx-config-v0"
 )

--- a/pkg/torcx/types.go
+++ b/pkg/torcx/types.go
@@ -15,14 +15,16 @@
 package torcx
 
 const (
-	// FUSE_PROFILE_NAME is the key label for fuse profile name
-	FUSE_PROFILE_NAME = "TORCX_PROFILE_NAME"
-	// FUSE_PROFILE_PATH is the key label for fuse profile path
-	FUSE_PROFILE_PATH = "TORCX_PROFILE_PATH"
-	// FUSE_BINDIR is the key label for fuse bindir
-	FUSE_BINDIR = "TORCX_BINDIR"
-	// FUSE_UNPACKDIR is the key label for fuse unpackdir
-	FUSE_UNPACKDIR = "TORCX_UNPACKDIR"
+	// SealUserProfile is the key label for user profile name
+	SealUserProfile = "TORCX_USER_PROFILE"
+	// SealVendorProfile is the key label for vendor profile path
+	SealVendorProfile = "TORCX_VENDOR_PROFILE"
+	// SealRunProfilePath is the key label for vendor profile path
+	SealRunProfilePath = "TORCX_PROFILE_PATH"
+	// SealBindir is the key label for seal bindir
+	SealBindir = "TORCX_BINDIR"
+	// SealUnpackdir is the key label for seal unpackdir
+	SealUnpackdir = "TORCX_UNPACKDIR"
 	// ProfileManifestV0K - profile manifest kind, v0
 	ProfileManifestV0K = "profile-manifest-v0"
 	// ImageManifestV0K - image manifest kind, v0
@@ -50,14 +52,16 @@ type CommonConfig struct {
 // the `apply` subcommand
 type ApplyConfig struct {
 	CommonConfig
-	Profile string
+	LowerProfile string
+	UpperProfile string
 }
 
 // ProfileConfig contains runtime configuration items specific to
 // the `profile` subcommand
 type ProfileConfig struct {
 	CommonConfig
-	CurrentProfileName string
+	UserProfileName    string
+	VendorProfileName  string
 	CurrentProfilePath string
 	NextProfile        string
 }


### PR DESCRIPTION
This introduces lower (vendor / oem ) and upper (user) profiles which are merged before applying.
The vendor profile is located by default at `/usr/share/torcx/profiles/vendor.json`.
The pem profile is located by default at `/usr/share/oem/torcx/profiles/oem.json`.
Entries in upper profile can override and mask those in lower profile.
Both profiles are optional from torcx point of view.

Closes https://github.com/coreos/torcx/issues/46
Closes https://github.com/coreos/torcx/issues/68