### PR TITLE
generator: add networkd units to image-manifest

### DIFF
--- a/Documentation/schemas/image-manifest-v0.md
+++ b/Documentation/schemas/image-manifest-v0.md
@@ -20,6 +20,8 @@ Note: The list of optional assets types will likely grow in the future. This is 
   Manifest content.
 - value/bin: array of string, arbitrary length.
   List of absolute paths for binaries to be propagated under torcx bin directory.
+- value/network: array of string, arbitrary length.
+  List of absolute paths of networkd units to be propagated under networkd runtime directory. This can reference single unit-files as well as directories (e.g. for ".conf" dropins)
 - value/units: array of string, arbitrary length.
   List of absolute paths of units to be propagated under systemd runtime directory. This can reference single unit-files as well as directories (e.g. for ".wants" and ".requires")
 
@@ -38,6 +40,12 @@ Note: The list of optional assets types will likely grow in the future. This is 
       "type": "object",
       "properties": {
         "bin": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "network": {
           "type": "array",
           "items": {
             "type": "string"

--- a/examples/image-manifest.json
+++ b/examples/image-manifest.json
@@ -4,6 +4,9 @@
       "bin": [
           "/usr/sbin/cupsd"
       ],
+      "network": [
+          "/lib/systemd/system/cups.network"
+      ],
       "units": [
           "/lib/systemd/system/cups.service",
           "/lib/systemd/system/printer.target.wants/"

--- a/pkg/torcx/perform.go
+++ b/pkg/torcx/perform.go
@@ -108,6 +108,16 @@ func ApplyProfile(applyCfg *ApplyConfig) error {
 			}).Debug("binaries propagated")
 		}
 
+		if len(assets.Network) > 0 {
+			if err := propagateNetworkdUnits(applyCfg, imageRoot, assets.Network); err != nil {
+				return errors.Wrapf(err, "propagating networkd units for image %q", im.Name)
+			}
+			logrus.WithFields(logrus.Fields{
+				"image":  im.Name,
+				"assets": assets.Network,
+			}).Debug("networkd units propagated")
+		}
+
 		if len(assets.Units) > 0 {
 			if err := propagateSystemdUnits(applyCfg, imageRoot, assets.Units); err != nil {
 				return errors.Wrapf(err, "propagating systemd units for image %q", im.Name)

--- a/pkg/torcx/types.go
+++ b/pkg/torcx/types.go
@@ -101,5 +101,6 @@ type ImageManifestV0 struct {
 // Assets holds lists of assets propagated from an image to the system
 type Assets struct {
 	Binaries []string `json:"bin,omitempty"`
+	Network  []string `json:"network,omitempty"`
 	Units    []string `json:"units,omitempty"`
 }


### PR DESCRIPTION
This adds a new `network` field to image-manifest to propagate networkd assets.

A complete sample manifest now looks like this:
```
{
  "kind": "image-manifest-v0",
  "value": {
      "bin": [
          "/usr/sbin/cupsd"
      ],
      "network": [
          "/lib/systemd/system/cups.network"
      ],
      "units": [
          "/lib/systemd/system/cups.service",
          "/lib/systemd/system/printer.target.wants/"
      ]
  }
}
```

/cc @dm0- 