### PR TITLE
profile: continue if /etc/torcx doesn't exist

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -66,8 +66,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 // fillApplyRuntime generate runtime config for apply subcommand starting from
 // system-wide configuration
 func fillApplyRuntime(commonCfg *torcx.CommonConfig) (*torcx.ApplyConfig, error) {
-	// We ignore the error here; NextProfileName will always return something we
-	// can apply, but also returns errors for other uses
+	// If we fail to read /etc/torcx/next-profile, report the error and use the default
 	profileName, err := commonCfg.NextProfileName()
 	if err != nil {
 		logrus.Warn("Falling back to default profile:", err)

--- a/cli/profile.go
+++ b/cli/profile.go
@@ -58,7 +58,8 @@ func fillProfileRuntime(commonCfg *torcx.CommonConfig) (*torcx.ProfileConfig, er
 
 	nextProfile, err = commonCfg.NextProfileName()
 	if err != nil {
-		return nil, err
+		logrus.Warnf("cannot read %s: %v - using default", commonCfg.NextProfile(), err)
+		nextProfile = torcx.DEFAULT_PROFILE_NAME
 	}
 
 	logrus.WithFields(logrus.Fields{

--- a/cli/profile_new.go
+++ b/cli/profile_new.go
@@ -66,6 +66,11 @@ func runProfileNew(cmd *cobra.Command, args []string) error {
 			return cmd.Usage()
 		}
 
+		// Only if a profile name is specified: make the directory
+		if err := os.MkdirAll(commonCfg.UserProfileDir(), 0755); err != nil {
+			return errors.Wrapf(err, "could not make profile directory %s", commonCfg.UserProfileDir())
+		}
+
 		if _, ok := profiles[flagProfileNewName]; ok {
 			return fmt.Errorf("profile %s already exists", flagProfileNewName)
 		}

--- a/cli/profile_use_image.go
+++ b/cli/profile_use_image.go
@@ -77,7 +77,7 @@ func runProfileUse(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("profile %s does not exist", flagProfileUseName)
 		}
 
-		flagProfileUseFile = filepath.Join(commonCfg.UserProfileDir(), flagProfileUseName)
+		flagProfileUseFile = filepath.Join(commonCfg.UserProfileDir(), flagProfileUseName+".json")
 	}
 
 	if flagProfileUseFile == "" {

--- a/pkg/torcx/profile.go
+++ b/pkg/torcx/profile.go
@@ -95,6 +95,9 @@ func (cc *CommonConfig) NextProfileName() (string, error) {
 
 // SetNextProfileName writes the given profile name as active for the next boot.
 func (cc *CommonConfig) SetNextProfileName(name string) error {
+	if err := os.MkdirAll(cc.UserProfileDir(), 0755); err != nil {
+		return err
+	}
 	return ioutil.WriteFile(cc.NextProfile(), []byte(name), 0644)
 }
 


### PR DESCRIPTION
Do something sensible if /etc/torcx doesn't exist - either ignore the error, or create it, depending on the circumstances.

Fixes: #63