### PR TITLE
store: add support for versioned stores

### DIFF
--- a/Documentation/design/paths.md
+++ b/Documentation/design/paths.md
@@ -19,7 +19,9 @@ Derived from configurables (shown with defaults):
 * NextProfile: ConfDir + `next-profile` (`/etc/torcx/next-profile`)
 * StoreDir:
   * (vendor) VendorDir + `store/` (`/usr/share/torcx/store/`)
+  * (versioned-oem) OemDir + `store/` + CurOSVer (`/usr/share/oem/torcx/store/<CurOSVer>/`)
   * (oem) OemDir + `store/` (`/usr/share/oem/torcx/store`)
+  * (versioned-user) BaseDir + `store/` + CurOSVer (`/var/lib/torcx/store/<CurOSVer>/`)
   * (user) BaseDir + `store/` (`/var/lib/torcx/store/`)
   * (runtime) `$TORCX_STOREPATH`
 * AuthDir: 

--- a/cli/common_test.go
+++ b/cli/common_test.go
@@ -1,0 +1,102 @@
+// Copyright 2017 CoreOS Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestFillCommon(t *testing.T) {
+	vendorStore := "/usr/share/torcx/store/"
+	tests := []struct {
+		desc string
+
+		isErr   bool
+		basedir string
+		rundir  string
+		confdir string
+	}{
+		{
+			"basic",
+			false,
+			"/var/lib/torcx/",
+			"/run/torcx/",
+			"/etc/torcx/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Logf("Testing %q", tt.desc)
+		cfg, err := fillCommonRuntime()
+		if tt.isErr {
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if cfg != nil {
+				t.Fatalf("expected nil config, got %#v", cfg)
+			}
+			continue
+		}
+		if cfg == nil {
+			t.Fatal("expected config, got nil")
+		}
+		if cfg.BaseDir != tt.basedir {
+			t.Fatalf("wrong basedir: expected %q, got %q", tt.basedir, cfg.BaseDir)
+		}
+		if cfg.RunDir != tt.rundir {
+			t.Fatalf("wrong rundir: expected %q, got %q", tt.rundir, cfg.RunDir)
+		}
+		if cfg.ConfDir != tt.confdir {
+			t.Fatalf("wrong rundir: expected %q, got %q", tt.confdir, cfg.ConfDir)
+		}
+		if len(cfg.StorePaths) == 0 {
+			t.Fatal("no store paths")
+		}
+		foundVendor := false
+		for _, path := range cfg.StorePaths {
+			if path == vendorStore {
+				foundVendor = true
+			}
+		}
+		if !foundVendor {
+			t.Fatalf("vendor store %q not found in %#v", vendorStore, cfg.StorePaths)
+		}
+	}
+}
+
+func TestHasExpFeature(t *testing.T) {
+	tests := map[string]bool{
+		"a": true,
+		"B": true,
+		"c": false,
+		"A": false,
+	}
+
+	for key, expFeat := range tests {
+		envKey := "TORCX_EXP_" + strings.ToUpper(key)
+		os.Unsetenv(envKey)
+		if expFeat {
+			os.Setenv(envKey, "y")
+		}
+
+		gotFeat := hasExpFeature(key)
+		if gotFeat != expFeat {
+			t.Errorf("Testcase %q failed, expected %t got %t", key, expFeat, gotFeat)
+
+		}
+	}
+}

--- a/cli/image_fetch.go
+++ b/cli/image_fetch.go
@@ -29,10 +29,12 @@ var (
 		Short: "Locally fetch a remote torcx image",
 		RunE:  runImageFetch,
 	}
+	flagTargetVersionID string
 )
 
 func init() {
 	if hasExpFeature("FETCH") {
+		cmdImageFetch.Flags().StringVarP(&flagTargetVersionID, "os-release", "n", "", "target OS release version")
 		cmdImage.AddCommand(cmdImageFetch)
 	}
 }
@@ -50,7 +52,7 @@ func runImageFetch(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "common configuration failed")
 	}
 
-	userStorePath := commonCfg.UserStorePath()
+	userStorePath := commonCfg.UserStorePath(flagTargetVersionID)
 	err = os.MkdirAll(userStorePath, 0755)
 	if err != nil {
 		return err

--- a/ftests/torcx_image_list_test.go
+++ b/ftests/torcx_image_list_test.go
@@ -1,0 +1,206 @@
+// Copyright 2017 CoreOS Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ftests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/torcx/cli"
+	"github.com/coreos/torcx/pkg/torcx"
+)
+
+func TestImageListEmpty(t *testing.T) {
+	if !IsInContainer() {
+		cfg := RktConfig{
+			imageName: EmptyImage,
+		}
+		RunTestInContainer(t, cfg)
+		return
+	}
+
+	cmd := exec.Command("torcx", "image", "list", "-v=error")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	var imgList cli.ImageList
+	err = json.NewDecoder(bytes.NewReader(b)).Decode(&imgList)
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	imgLen := len(imgList.Value)
+	if imgLen != 0 {
+		t.Log(string(b))
+		t.Fatalf("Expected %d images, got %d", 1, imgLen)
+	}
+}
+
+func TestImageListVendor(t *testing.T) {
+	if !IsInContainer() {
+		cfg := RktConfig{
+			imageName: VendorImage,
+		}
+		RunTestInContainer(t, cfg)
+		return
+	}
+
+	cmd := exec.Command("torcx", "image", "list", "-v=error")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	var imgList cli.ImageList
+	err = json.NewDecoder(bytes.NewReader(b)).Decode(&imgList)
+	if err != nil {
+		t.Log(string(b))
+		t.Error(err)
+	}
+
+	imgLen := len(imgList.Value)
+	if imgLen != 1 {
+		t.Log(string(b))
+		t.Fatalf("Expected %d images, got %d", 1, imgLen)
+	}
+
+	expName := "empty_vendor"
+	expRef := "com.coreos.cl"
+	expPath := fmt.Sprintf("/usr/share/torcx/store/%s:%s.torcx.tgz", expName, expRef)
+	imgName := imgList.Value[0].Name
+	imgRef := imgList.Value[0].Reference
+	imgPath := imgList.Value[0].Filepath
+	if imgName != expName {
+		t.Errorf("Expected image name %q, got %q", expName, imgName)
+	}
+	if imgRef != expRef {
+		t.Errorf("Expected image reference %q, got %q", expRef, imgRef)
+	}
+	if imgPath != expPath {
+		t.Errorf("Expected image path %q, got %q", expPath, imgPath)
+	}
+}
+
+func TestImageListUser(t *testing.T) {
+	if !IsInContainer() {
+		cfg := RktConfig{
+			imageName: VendorImage,
+		}
+		RunTestInContainer(t, cfg)
+		return
+	}
+
+	expName := "empty_vendor"
+	expRef := "com.coreos.cl"
+	OSVersion := "1.2.3"
+	OSEntry := bytes.NewBufferString(fmt.Sprintf("VERSION_ID=%s\n", OSVersion))
+	userStore := "/var/lib/torcx/store"
+
+	if err := os.MkdirAll(filepath.Dir(torcx.OsReleasePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(torcx.OsReleasePath, OSEntry.Bytes(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// These just re-use the vendor package embedded in the ACI,
+	// moving/symlinking it around across stores.
+	tests := []struct {
+		desc    string
+		store   string
+		oldPath string
+		imgPath string
+		doMove  bool
+	}{
+		{
+			"user store",
+			userStore,
+			fmt.Sprintf("/usr/share/torcx/store/%s:%s.torcx.tgz", expName, expRef),
+			fmt.Sprintf("%s/%s:%s.torcx.tgz", userStore, expName, expRef),
+			true,
+		},
+		{
+			"user versioned store",
+			filepath.Join(userStore, OSVersion),
+			fmt.Sprintf("%s/%s:%s.torcx.tgz", userStore, expName, expRef),
+			fmt.Sprintf("%s/%s/%s:%s.torcx.tgz", userStore, OSVersion, expName, expRef),
+			false, // Just symlink, and check for proper shadowing
+		},
+	}
+
+	for _, tt := range tests {
+		t.Logf("Testing %q", tt.desc)
+		err := os.MkdirAll(tt.store, 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tt.doMove {
+			err = os.Rename(tt.oldPath, tt.imgPath)
+		} else {
+			err = os.Symlink(tt.oldPath, tt.imgPath)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := exec.Command("torcx", "image", "list", "-v=error")
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Log(string(b))
+			t.Fatal(err)
+		}
+
+		var imgList cli.ImageList
+		err = json.NewDecoder(bytes.NewReader(b)).Decode(&imgList)
+		if err != nil {
+			t.Log(string(b))
+			t.Fatal(err)
+		}
+
+		imgLen := len(imgList.Value)
+		if imgLen != 1 {
+			t.Log(string(b))
+			t.Fatalf("Expected %d images, got %d", 1, imgLen)
+		}
+		checkImage(t, imgList.Value[0].Archive, expName, expRef, tt.imgPath)
+	}
+
+}
+
+func checkImage(t *testing.T, entry torcx.Archive, expName, expRef, expPath string) {
+	imgName := entry.Name
+	imgRef := entry.Reference
+	imgPath := entry.Filepath
+	if imgName != expName {
+		t.Errorf("Expected image name %q, got %q", expName, imgName)
+	}
+	if imgRef != expRef {
+		t.Errorf("Expected image reference %q, got %q", expRef, imgRef)
+	}
+	if imgPath != expPath {
+		t.Errorf("Expected image path %q, got %q", expPath, imgPath)
+	}
+}

--- a/pkg/torcx/build_constants.go
+++ b/pkg/torcx/build_constants.go
@@ -22,6 +22,8 @@ const (
 	VendorDir = "/usr/share/torcx/"
 	// OemDir contains (mutable) assets provided by the oem.
 	OemDir = "/usr/share/oem/torcx/"
+	// OsReleasePath contains the current os-release version.
+	OsReleasePath = "/usr/share/coreos/os-release"
 	// DefaultTagRef is the default image reference looked up in archives.
 	DefaultTagRef = "com.coreos.cl"
 	// VendorProfileName is the default vendor profile used.

--- a/pkg/torcx/paths.go
+++ b/pkg/torcx/paths.go
@@ -65,9 +65,14 @@ func (cc *CommonConfig) RunProfile() string {
 	return filepath.Join(cc.RunDir, "profile.json")
 }
 
-// UserStorePath  is the path where user-fetched archives are written.
-func (cc *CommonConfig) UserStorePath() string {
-	return filepath.Join(cc.BaseDir, "store")
+// UserStorePath is the path where user-fetched archives are written.
+// An optional target version can be specified for versioned user store.
+func (cc *CommonConfig) UserStorePath(version string) string {
+	storePath := filepath.Join(cc.BaseDir, "store")
+	if version != "" {
+		storePath = filepath.Join(storePath, version)
+	}
+	return storePath
 }
 
 // AuthDir will have docker trust roots. It is currently unused.

--- a/pkg/torcx/perform_test.go
+++ b/pkg/torcx/perform_test.go
@@ -1,0 +1,81 @@
+// Copyright 2017 CoreOS Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package torcx
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetOsReleaseID(t *testing.T) {
+	tests := []struct {
+		desc    string
+		content string
+
+		expVer string
+		expErr error
+	}{
+		{
+			"empty",
+			"",
+
+			"",
+			ErrUnknownOSVersionID,
+		},
+		{
+			"positive",
+			"VERSION_ID=1.0.0",
+
+			"1.0.0",
+			nil,
+		},
+		{
+			"positive with empty lines",
+			"\nVERSION_ID=1.0.0\n",
+
+			"1.0.0",
+			nil,
+		},
+		{
+			"missing key",
+			"=1.0.0",
+
+			"",
+			ErrUnknownOSVersionID,
+		},
+		{
+			"missing value",
+			"VERSION_ID=",
+
+			"",
+			ErrUnknownOSVersionID,
+		},
+	}
+
+	for _, tt := range tests {
+		rd := strings.NewReader(tt.content)
+		ver, err := parseOsVersionID(rd)
+		if err != tt.expErr {
+			t.Errorf("testcase %q failed with mismatched error:\n got: %v\n expected: %v", tt.desc, err, tt.expErr)
+		}
+		if tt.expErr != nil {
+			continue
+		}
+		if ver != tt.expVer {
+			t.Fatalf("testcase %q failed with mismatched version-id result: got %q - expected %q", tt.desc, err, tt.expVer)
+		}
+	}
+
+}


### PR DESCRIPTION
This PR introduces support for versioned stores, which are enabled by the generator and the userland tool when a matching os-release is detected. With this change, two additional stores are also conditionally inspected for images:
 * versioned-oem: `/usr/share/oem/torcx/store/<CurOSVer>/`
 * versioned-user: `/var/lib/torcx/store/<CurOSVer>/`

Fixes: https://github.com/coreos/torcx/issues/74