### PR TITLE
pkg: update os-release path

### DIFF
--- a/pkg/torcx/build_constants.go
+++ b/pkg/torcx/build_constants.go
@@ -23,7 +23,7 @@ const (
 	// OemDir contains (mutable) assets provided by the oem.
 	OemDir = "/usr/share/oem/torcx/"
 	// OsReleasePath contains the current os-release version.
-	OsReleasePath = "/usr/share/coreos/os-release"
+	OsReleasePath = "/usr/lib/os-release"
 	// DefaultTagRef is the default image reference looked up in archives.
 	DefaultTagRef = "com.coreos.cl"
 	// VendorProfileName is the default vendor profile used.


### PR DESCRIPTION
This updates torcx to use the canonical path for the os-release file,
instead of the CoreOS specific one.