### PR TITLE
[WIP] torcx/perform: don't store unpacked data in /run

### DIFF
--- a/pkg/torcx/paths.go
+++ b/pkg/torcx/paths.go
@@ -41,14 +41,15 @@ const (
 	defaultCfgPath = DefaultConfDir + "config.json"
 )
 
-// UnpackDir is the directory where root filesystems are unpacked
-func (cc *CommonConfig) UnpackDir() string {
+// InternalUnpackDir is the directory where root filesystems are unpacked.
+func (cc *CommonConfig) InternalUnpackDir() string {
 	return filepath.Join(cc.BaseDir, "unpack")
 }
 
-// RunUnpackDir is the directory where the set of unpacked root filesystems is
-// unpacked for runtime usage.
-func (cc *CommonConfig) RunUnpackDir() string {
+// UnpackDir is the directory where root filesystems are available at runtime.
+// UnpackDir acts as the public interface to the UnpackDir. It is where
+// users of torcx may expect to find image's contents.
+func (cc *CommonConfig) UnpackDir() string {
 	return filepath.Join(cc.RunDir, "unpack")
 }
 

--- a/pkg/torcx/paths.go
+++ b/pkg/torcx/paths.go
@@ -41,7 +41,13 @@ const (
 	defaultCfgPath = DefaultConfDir + "config.json"
 )
 
-// RunUnpackDir is the directory where root filesystems are unpacked.
+// UnpackDir is the directory where root filesystems are unpacked
+func (cc *CommonConfig) UnpackDir() string {
+	return filepath.Join(cc.BaseDir, "unpack")
+}
+
+// RunUnpackDir is the directory where the set of unpacked root filesystems is
+// unpacked for runtime usage.
 func (cc *CommonConfig) RunUnpackDir() string {
 	return filepath.Join(cc.RunDir, "unpack")
 }

--- a/pkg/torcx/perform.go
+++ b/pkg/torcx/perform.go
@@ -232,13 +232,6 @@ func SealSystemState(applyCfg *ApplyConfig) error {
 		}
 	}
 
-	// Remount the unpackdir RO
-	if err := unix.Mount(applyCfg.UnpackDir(), applyCfg.UnpackDir(),
-		"", unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
-
-		return errors.Wrap(err, "failed to remount read-only")
-	}
-
 	logrus.WithFields(logrus.Fields{
 		"path":    SealPath,
 		"content": content,
@@ -296,7 +289,7 @@ func setupPaths(applyCfg *ApplyConfig) error {
 	// In addition, this is done for backwards compatibility; previously the
 	// 'UnpackDir' did not exist and the 'RunUnpackDir' was both the source of
 	// truth and store of data.
-	if err := unix.Mount(applyCfg.UnpackDir(), applyCfg.RunUnpackDir(), "", unix.MS_BIND|unix.MS_REC|unix.MS_SLAVE, ""); err != nil {
+	if err := unix.Mount(applyCfg.UnpackDir(), applyCfg.RunUnpackDir(), "", unix.MS_RDONLY|unix.MS_BIND|unix.MS_REC|unix.MS_SLAVE, ""); err != nil {
 		return errors.Wrap(err, "failed to bindmount unpackdir")
 	}
 

--- a/pkg/torcx/types.go
+++ b/pkg/torcx/types.go
@@ -23,7 +23,7 @@ const (
 	SealRunProfilePath = "TORCX_PROFILE_PATH"
 	// SealBindir is the key label for seal bindir
 	SealBindir = "TORCX_BINDIR"
-	// SealUnpackdir is the key label for seal unpackdir
+	// SealUnpackdir is the key label for seal runtime unpackdir path
 	SealUnpackdir = "TORCX_UNPACKDIR"
 	// ProfileManifestV0K - profile manifest kind, v0
 	ProfileManifestV0K = "profile-manifest-v0"


### PR DESCRIPTION
This is marked WIP because I need to still:
1. ~~Build and test a real image with this on qemu and/or AWS~~ done
2. Talk through whether this does the right thing on PXE (I think it's fine, but my knowledge is shaky there) and probably give it a test there too.

Note as well, this will slow boot somewhat due to doing more disk IO; I think the memory problem is severe enough that the tradeoff is right, but it's worth pointing out.

Comments on the approach are also welcome; since the code to implement "unpack in var, bindmount to run" is small enough, I felt discussion of the approach would fit fine here.

------------------------------

Using /run meant large packages, like Docker Community Edition by Docker
Inc., took up large chunks of memory even if the binaries were never
run.

This replaces the previous behavior with the use of
`/var/lib/torcx/unpack` as the primary unpack directory.

The binaries are still located in `/run/torcx` as well via a bindmount.
This retains backwards compatibility and, in addition, provides a
potentially useful decoupling between where the data is referenced and
where it is actually stored.