### PR TITLE
image: propagate udev rules files

### DIFF
--- a/Documentation/design/images.md
+++ b/Documentation/design/images.md
@@ -29,6 +29,7 @@ It currently looks for:
 * systemd network units
 * sysusers files
 * tmpfiles files
+* udev rules
 
 [schemas]: ./schemas.md
 [paths]: ./paths.md

--- a/Documentation/schemas/image-manifest-v0.md
+++ b/Documentation/schemas/image-manifest-v0.md
@@ -28,6 +28,8 @@ Note: The list of optional assets types will likely grow in the future. This is 
   List of absolute paths of files to be propagated under `sysusers.d` directory.
 - value/tmpfiles: array of string, arbitrary length.
   List of absolute paths of files to be propagated under `tmpfiles.d` directory.
+- value/udev_rules: array of string, arbitrary length.
+  List of absolute paths of udev rules to be propagated under `rules.d` directory.
 
 ## JSON schema
 
@@ -72,8 +74,13 @@ Note: The list of optional assets types will likely grow in the future. This is 
           "items": {
             "type": "string"
           }
+        },
+        "udev_rules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
-
       }
     }
   },

--- a/internal/torcx/perform.go
+++ b/internal/torcx/perform.go
@@ -183,7 +183,14 @@ func applyImages(applyCfg *ApplyConfig, images Images) error {
 			logrus.WithFields(logFields).WithField("assets", assets.Units).Debug("tmpfiles propagated")
 		}
 
-		// TODO(lucab): evaluate and propagate more units types
+		if len(assets.UdevRules) > 0 {
+			if err := propagateUdevRules(applyCfg, imageRoot, assets.UdevRules); err != nil {
+				failedImages = append(failedImages, im)
+				logrus.WithFields(logFields).WithField("assets", assets.UdevRules).Error("failed to propagate udev rules: ", err)
+				continue
+			}
+			logrus.WithFields(logFields).WithField("assets", assets.UdevRules).Debug("udev rules propagated")
+		}
 	}
 
 	if len(failedImages) > 0 {

--- a/internal/torcx/propagate.go
+++ b/internal/torcx/propagate.go
@@ -28,11 +28,12 @@ import (
 const (
 	// manifestPath is the well-known location for image manifest
 	manifestPath = "/.torcx/manifest.json"
-	// systemdDir is the runtime systemd base path
 	// TODO(lucab): possibly not constant, group all link-time parameter together
-	systemdDir  = "/run/systemd"
-	sysUsersDir = "/run/sysusers.d"
-	tmpFilesDir = "/run/tmpfiles.d"
+	// systemdDir is the runtime systemd base path
+	systemdDir   = "/run/systemd"
+	sysUsersDir  = "/run/sysusers.d"
+	tmpFilesDir  = "/run/tmpfiles.d"
+	udevRulesDir = "/run/udev/rules.d"
 )
 
 func retrieveAssets(applyCfg *ApplyConfig, imageRoot string) (*Assets, error) {
@@ -77,13 +78,19 @@ func propagateSystemdUnits(applyCfg *ApplyConfig, imageRoot string, units []stri
 	return propagateUnits(applyCfg, imageRoot, units, sdUnitsDir)
 }
 
-// propagateSysusersUnits installs sysusers config in /run/sysusers.d
+// propagateSysusersUnits installs sysusers files as runtime configuration (in /run/sysusers.d/).
 func propagateSysusersUnits(applyCfg *ApplyConfig, imageRoot string, units []string) error {
 	return propagateUnits(applyCfg, imageRoot, units, sysUsersDir)
 }
 
+// propagateTmpfilesUnits installs tmpfiles files as runtime configuration (in /run/tmpfiles.d/).
 func propagateTmpfilesUnits(applyCfg *ApplyConfig, imageRoot string, units []string) error {
 	return propagateUnits(applyCfg, imageRoot, units, tmpFilesDir)
+}
+
+// propagateUdevRules installs udev rules as runtime configuration (in /run/udev/rules.d/).
+func propagateUdevRules(applyCfg *ApplyConfig, imageRoot string, udevRules []string) error {
+	return propagateUnits(applyCfg, imageRoot, udevRules, udevRulesDir)
 }
 
 // propagateUnits installs unit assets as runtime units for systemd/networkd/etc.

--- a/internal/torcx/types.go
+++ b/internal/torcx/types.go
@@ -96,9 +96,10 @@ type ImageManifestV0 struct {
 
 // Assets holds lists of assets propagated from an image to the system
 type Assets struct {
-	Binaries []string `json:"bin,omitempty"`
-	Network  []string `json:"network,omitempty"`
-	Units    []string `json:"units,omitempty"`
-	Sysusers []string `json:"sysusers,omitempty"`
-	Tmpfiles []string `json:"tmpfiles,omitempty"`
+	Binaries  []string `json:"bin,omitempty"`
+	Network   []string `json:"network,omitempty"`
+	Units     []string `json:"units,omitempty"`
+	Sysusers  []string `json:"sysusers,omitempty"`
+	Tmpfiles  []string `json:"tmpfiles,omitempty"`
+	UdevRules []string `json:"udev_rules,omitempty"`
 }


### PR DESCRIPTION
This introduces a `udev_rules` field in image manifest in order to
propagate udev rules contained within an image.