### PR TITLE
examples: add a target unit for torcx

### DIFF
--- a/examples/torcx.target
+++ b/examples/torcx.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=Verify torcx succeeded
+DefaultDependencies=no
+AssertPathExists=/run/metadata/torcx
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
This adds an example systemd target unit, which tracks proper
torcx-generator run by checking for the seal file. This example is
lifted from ContainerLinux:
https://github.com/coreos/coreos-overlay/pull/2567

Closes: https://github.com/coreos/torcx/issues/51