### PR TITLE
internal: rework and split JSON config types

### DIFF
--- a/fixtures/test-invalid-profile.json
+++ b/fixtures/test-invalid-profile.json
@@ -1,0 +1,11 @@
+{
+  "kind": "profile-manifest-invalid",
+  "value": {
+    "images": [
+      {
+        "name": "test-name",
+        "reference": "test-reference"
+      }
+    ]
+  }
+}

--- a/ftests/generator_test.go
+++ b/ftests/generator_test.go
@@ -144,7 +144,7 @@ func testDockerFlag(t *testing.T, setup func(*testing.T), expRef string) {
 }
 
 func checkProfileSelection(t *testing.T, expName, expRef string) {
-	var profManifest torcx.ProfileManifestV0
+	var profManifest torcx.ProfileManifestV0JSON
 	fp, err := os.Open("/run/torcx/profile.json")
 	if err != nil {
 		t.Error(err)

--- a/internal/cli/profile_check.go
+++ b/internal/cli/profile_check.go
@@ -89,7 +89,7 @@ func runProfileCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	// Empty profiles are allowed
-	if len(profile.Images) == 0 {
+	if len(profile) == 0 {
 		logrus.Warn("Profile specifies no images")
 		return nil
 	}
@@ -100,7 +100,7 @@ func runProfileCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	missing := false
-	for _, im := range profile.Images {
+	for _, im := range profile {
 		ar, err := storeCache.ArchiveFor(im)
 		if err != nil {
 			missing = true

--- a/internal/cli/profile_new.go
+++ b/internal/cli/profile_new.go
@@ -130,10 +130,10 @@ func copyProfile(profiles map[string]string, fromName string, toPath string) err
 }
 
 func newBlankProfile(toPath string) error {
-	blank := torcx.ProfileManifestV0{
+	blank := torcx.ProfileManifestV0JSON{
 		Kind: torcx.ProfileManifestV0K,
-		Value: torcx.Images{
-			Images: []torcx.Image{},
+		Value: torcx.ImagesV0{
+			Images: []torcx.ImageV0{},
 		},
 	}
 

--- a/internal/torcx/json_input.go
+++ b/internal/torcx/json_input.go
@@ -1,0 +1,39 @@
+// Copyright 2018 CoreOS Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package torcx
+
+const (
+	// ProfileManifestV0K - profile manifest kind, v0
+	ProfileManifestV0K = "profile-manifest-v0"
+)
+
+// * Profile manifest version 0: initial version.
+
+// ProfileManifestV0JSON holds JSON profile manifest (version 0).
+type ProfileManifestV0JSON struct {
+	Kind  string   `json:"kind"`
+	Value ImagesV0 `json:"value"`
+}
+
+// ImagesV0 contains an array of image entries.
+type ImagesV0 struct {
+	Images []ImageV0 `json:"images"`
+}
+
+// ImageV0 represents an addon archive (name + reference).
+type ImageV0 struct {
+	Name      string `json:"name"`
+	Reference string `json:"reference"`
+}

--- a/internal/torcx/perform.go
+++ b/internal/torcx/perform.go
@@ -58,15 +58,15 @@ func ApplyProfile(applyCfg *ApplyConfig) error {
 	if err != nil {
 		return err
 	}
-	if len(images.Images) > 0 {
+	if len(images) > 0 {
 		if err := applyImages(applyCfg, images); err != nil {
 			return err
 		}
 	}
 
-	runProfile := ProfileManifestV0{
+	runProfile := ProfileManifestV0JSON{
 		Kind:  ProfileManifestV0K,
-		Value: images,
+		Value: ImagesToJSONV0(images),
 	}
 	rpp, err := os.Create(applyCfg.RunProfile())
 	if err != nil {
@@ -94,7 +94,7 @@ func ApplyProfile(applyCfg *ApplyConfig) error {
 }
 
 // applyImages unpacks and propagates assets from a list of images.
-func applyImages(applyCfg *ApplyConfig, images Images) error {
+func applyImages(applyCfg *ApplyConfig, images []Image) error {
 	if applyCfg == nil {
 		return errors.New("missing apply configuration")
 	}
@@ -107,7 +107,7 @@ func applyImages(applyCfg *ApplyConfig, images Images) error {
 	// Unpack all images, continuing on error
 	failedImages := []Image{}
 
-	for _, im := range images.Images {
+	for _, im := range images {
 		// Some log fields we keep using
 		logFields := logrus.Fields{
 			"image":     im.Name,

--- a/internal/torcx/store.go
+++ b/internal/torcx/store.go
@@ -115,8 +115,11 @@ func NewStoreCache(paths []string) (StoreCache, error) {
 // ArchiveFor looks for a reference in the store, returning the path
 // to the archive containing it
 func (sc *StoreCache) ArchiveFor(im Image) (Archive, error) {
-	if arch, ok := sc.Images[im]; ok {
-		return arch, nil
+	for entry, archive := range sc.Images {
+		if im.Name == entry.Name &&
+			im.Reference == entry.Reference {
+			return archive, nil
+		}
 	}
 
 	return Archive{}, fmt.Errorf("image %s:%s not found", im.Name, im.Reference)


### PR DESCRIPTION
This reworks the logic responsible of handling profiles and images, in
order to split internal types and JSON configuration.
It also introduces some additional tests and fixtures.