### PR TITLE
schemas: add torcx-remote-contents-v1 schema 

### DIFF
--- a/Documentation/schemas/remote-contents-v1.md
+++ b/Documentation/schemas/remote-contents-v1.md
@@ -1,0 +1,137 @@
+# Torcx Remote Contents - v1
+
+A "remote contents" manifest is a JSON data structure hosted by remote repositories providing additional torcx image archives.
+It lists a set of images (with specific versions and formats) which can be retrieved from the specific remote.
+
+## Changes in v1
+
+This is loosely based on the tectonic-torcx package list v0, which does not have a formal specification (but looks like [this](https://tectonic-torcx.release.core-os.net/manifests/amd64-usr/1520.5.0/torcx_manifest.json)).
+
+Notable changes in v1 are:
+ * JSON schema specification
+ * manifest filename is now `torcx_manifest.json.asc`
+ * JSON content is now wrapped with an OpenPGP armored signature
+ * more consistent use of "image" terminology
+ * `kind` is no `torcx-remote-contents-v1`
+ * `location` takes a relative path which then resolves to `${base_url}/${location}`, or an absolute URL.
+
+## Manifest location and signature
+
+A remote contents manifest for a specific remote can be located by looking for a file called `torcx_manifest.json.asc` under the resolved remote `${base_url}`.
+
+This file contains a JSON object (schema described below), wrapped in an OpenPGP armored clearsign signature.
+
+Such signature can be verified against any of the keys specified in the remote manifest.
+
+## Schema
+
+The new schema is as follows:
+- kind: `torcx-remote-contents-v1`
+- value
+  - images (array, required, fixed-type, not-nil, min-lenght=0)
+    - name (string required)
+    - defaultVersion (string, optional)
+    - versions (array, required)
+        - format (string, required)
+        - hash (string, required)
+        - location (string, required)
+        - version (string, required)
+
+*NOTE*: `defaultVersion` is used to resolve the default vendor reference/symlink (e.g. `com.coreos.cl`).
+
+## Entries
+
+- kind: hardcoded to `torcx-remote-contents-v1` for this schema revision.
+  The type+version of this JSON manifest.
+- value: object containing a single typed key-value.
+  Manifest content.
+- value/images: array of single-type objects, arbitrary length.
+  List of images.
+- value/images/#: anonymous array entry, object
+- value/images/#/name: string.
+  Name of the image.
+- value/images/#/defaultVersion: string.
+  Default version which can be aliased by the default vendor reference (e.g. `com.coreos.cl`).
+- value/images/#/versions: array of single-type objects, arbitrary length.
+  List of archives.
+- value/images/#/versions/#: anonymous array entry, object
+- value/images/#/versions/#/format: string.
+  Archive format. Allowed values: "tgz", "squashfs".
+- value/images/#/versions/#/hash: string.
+- value/images/#/versions/#/location: string.
+  A relative path which then resolves to `${base_url}/${remoteFile}`, or an absolute URL.
+- value/images/#/versions/#/version: string.
+  Image version.
+
+## JSON schema
+
+```json
+
+{
+  "$schema": "http://json-schema.org/draft-05/schema#",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": ["torcx-remote-contents-v1"]
+    },
+    "value": {
+      "type": "object",
+      "properties": {
+        "images": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "defaultVersion": {
+                "type": "string"
+              },
+              "versions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "format": {
+                      "type": "string"
+                    },
+                    "hash": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "format",
+                    "hash",
+                    "location",
+                    "version"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "name",
+              "versions"
+            ]
+          }
+        }
+      },
+      "required": [
+        "images"
+      ]
+    }
+  },
+  "required": [
+    "kind",
+    "value"
+  ]
+}
+
+```

--- a/internal/torcx/json_input.go
+++ b/internal/torcx/json_input.go
@@ -21,6 +21,8 @@ const (
 	ProfileManifestV0K = "profile-manifest-v0"
 	// RemoteManifestV0K - remote manifest kind, v0
 	RemoteManifestV0K = "remote-manifest-v0"
+	// RemoteContentsV1K - remote contents kind, v1
+	RemoteContentsV1K = "torcx-remote-contents-v1"
 )
 
 // * Profile manifest version 1: added "remote".
@@ -79,4 +81,33 @@ type RemoteV0 struct {
 // RemoteKeyV0 represents a signing key for a remote.
 type RemoteKeyV0 struct {
 	ArmoredKeyring string `json:"armored_keyring,omitempty"`
+}
+
+// * Remote contents version 1: initial version.
+
+// RemoteContentsV1JSON holds JSON contents metadata for a remote manifest.
+type RemoteContentsV1JSON struct {
+	Kind  string         `json:"kind"`
+	Value RemoteImagesV1 `json:"value"`
+}
+
+// RemoteImagesV1 lists all images available on a remote.
+type RemoteImagesV1 struct {
+	Images []RemoteImageV1 `json:"images"`
+}
+
+// RemoteImageV1 describes image versions available on a remote.
+type RemoteImageV1 struct {
+	DefaultVersion string            `json:"defaultVersion"`
+	Name           string            `json:"name"`
+	Versions       []RemoteVersionV1 `json:"versions"`
+}
+
+// RemoteVersionV1 describes a specific image (with version and format)
+// available on a remote.
+type RemoteVersionV1 struct {
+	Format   string `json:"format"`
+	Hash     string `json:"hash"`
+	Location string `json:"location"`
+	Version  string `json:"version"`
 }

--- a/internal/torcx/types.go
+++ b/internal/torcx/types.go
@@ -241,6 +241,62 @@ func RemoteFromJSONV0(j RemoteV0) Remote {
 	return res
 }
 
+// RemoteContents holds contents metadata for a remote manifest.
+type RemoteContents struct {
+	Images map[string]RemoteImage
+}
+
+// RemoteContentsFromJSONV1 translates a RemoteImagesV1 to an internal Remote.
+func RemoteContentsFromJSONV1(j RemoteImagesV1) RemoteContents {
+	var res RemoteContents
+
+	images := map[string]RemoteImage{}
+	for _, im := range j.Images {
+		if im.Name == "" {
+			continue
+		}
+		tmpVersions := []RemoteVersion{}
+		for _, v := range im.Versions {
+			tmpVersions = append(tmpVersions, RemoteVersionFromJSONV1(v))
+		}
+		tmpImage := RemoteImage{
+			name:           im.Name,
+			defaultVersion: im.DefaultVersion,
+			versions:       tmpVersions,
+		}
+		images[im.Name] = tmpImage
+	}
+	res.Images = images
+
+	return res
+}
+
+// RemoteImage list remote versions of an image.
+type RemoteImage struct {
+	defaultVersion string
+	name           string
+	versions       []RemoteVersion
+}
+
+// RemoteVersion describes a remote image archive.
+type RemoteVersion struct {
+	format   string
+	version  string
+	hash     string
+	location string
+}
+
+// RemoteVersionFromJSONV1 translates a RemoteVersionV1 to an internal RemoteVersion.
+func RemoteVersionFromJSONV1(j RemoteVersionV1) RemoteVersion {
+	remoteVer := RemoteVersion{
+		format:   j.Format,
+		hash:     j.Hash,
+		version:  j.Version,
+		location: j.Location,
+	}
+	return remoteVer
+}
+
 // kindValueJSON holds a generic, typed, kind-value JSON manifest.
 type kindValueJSON struct {
 	Kind  string          `json:"kind"`


### PR DESCRIPTION
This introduces a new remote contents manifest, adding support
for inspecting the contents hosted by a remote.
This manifest will be consumed in the future to automatically populate
the local store from a remote source.