### PR TITLE
cli/common: make the USR mountpoint a runtime flag

### DIFF
--- a/internal/cli/image_list.go
+++ b/internal/cli/image_list.go
@@ -63,7 +63,7 @@ func runImageList(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			osRelease = ""
 		}
-		storePaths = torcx.FilterStoreVersions(commonCfg.StorePaths, osRelease, flagImageListOsVersion)
+		storePaths = torcx.FilterStoreVersions(commonCfg.UsrDir, commonCfg.StorePaths, osRelease, flagImageListOsVersion)
 	}
 	storeCache, err := torcx.NewStoreCache(storePaths)
 	if err != nil {

--- a/internal/torcx/build_constants.go
+++ b/internal/torcx/build_constants.go
@@ -18,8 +18,8 @@ package torcx
 const (
 	// SealPath is the path where metadata are written once the system has been sealed.
 	SealPath = "/run/metadata/torcx"
-	// VendorDir contains (immutable) assets provided by the vendor.
-	VendorDir = "/usr/share/torcx/"
+	// VendorUsrDir is the standard mountpoint for vendor USR partition.
+	VendorUsrDir = "/usr"
 	// OemDir contains (mutable) assets provided by the oem.
 	OemDir = "/usr/share/oem/torcx/"
 	// DefaultTagRef is the default image reference looked up in archives.

--- a/internal/torcx/paths.go
+++ b/internal/torcx/paths.go
@@ -26,23 +26,40 @@ const (
 	// DefaultConfDir is the default torcx config directory
 	DefaultConfDir = "/etc/torcx/"
 
-	// VendorStoreDir is the vendor store path
-	VendorStoreDir = VendorDir + "store/"
-	// VendorProfilesDir is the vendor profiles path
-	VendorProfilesDir = VendorDir + "profiles/"
-	// VendorRemotesDir is the vendor remotes path
-	VendorRemotesDir = VendorDir + "remotes/"
-
 	// OemStoreDir is the OEM store path
-	OemStoreDir = OemDir + "store/"
+	OemStoreDir = OemDir + "store"
 	// OemProfilesDir is the OEM profiles path
-	OemProfilesDir = OemDir + "profiles/"
+	OemProfilesDir = OemDir + "profiles"
 	// OemRemotesDir is the OEM remotes path
-	OemRemotesDir = OemDir + "remotes/"
+	OemRemotesDir = OemDir + "remotes"
 
 	// defaultCfgPath is the default path for common torcx config
 	defaultCfgPath = DefaultConfDir + "config.json"
 )
+
+// VendorRemotesDir is the vendor remotes path
+func VendorRemotesDir(usrMountpoint string) string {
+	if usrMountpoint == "" {
+		usrMountpoint = VendorUsrDir
+	}
+	return filepath.Join(usrMountpoint, "share", "torcx", "remotes")
+}
+
+// VendorProfilesDir is the vendor profiles path
+func VendorProfilesDir(usrMountpoint string) string {
+	if usrMountpoint == "" {
+		usrMountpoint = VendorUsrDir
+	}
+	return filepath.Join(usrMountpoint, "share", "torcx", "profiles")
+}
+
+// VendorStoreDir is the vendor store path
+func VendorStoreDir(usrMountpoint string) string {
+	if usrMountpoint == "" {
+		usrMountpoint = VendorUsrDir
+	}
+	return filepath.Join(usrMountpoint, "share", "torcx", "store")
+}
 
 // RunUnpackDir is the directory where root filesystems are unpacked.
 func (cc *CommonConfig) RunUnpackDir() string {
@@ -57,7 +74,7 @@ func (cc *CommonConfig) RunBinDir() string {
 // ProfileDirs are the list of directories where we look for profiles.
 func (cc *CommonConfig) ProfileDirs() []string {
 	return []string{
-		VendorProfilesDir,
+		VendorProfilesDir(cc.UsrDir),
 		OemProfilesDir,
 		cc.UserProfileDir(),
 	}
@@ -92,7 +109,7 @@ func (cc *CommonConfig) NextProfile() string {
 // for the specific OS partition mounted at `usrMountpoint`.
 func VendorOsReleasePath(usrMountpoint string) string {
 	if usrMountpoint == "" {
-		usrMountpoint = "/usr"
+		usrMountpoint = VendorUsrDir
 	}
 	return filepath.Join(usrMountpoint, "lib", "os-release")
 }

--- a/internal/torcx/store.go
+++ b/internal/torcx/store.go
@@ -146,7 +146,7 @@ func (sc *StoreCache) ArchiveFor(im Image) (Archive, error) {
 
 // FilterStoreVersions filters out unversioned store based on the match between the
 // currently detected OS version (`curVersion`) and the one to filter for (`filterVersion`)
-func FilterStoreVersions(paths []string, curVersion string, filterVersion string) []string {
+func FilterStoreVersions(usrMountpoint string, paths []string, curVersion string, filterVersion string) []string {
 	if len(paths) <= 0 || filterVersion == "" {
 		return paths
 	}
@@ -157,7 +157,7 @@ func FilterStoreVersions(paths []string, curVersion string, filterVersion string
 	retPaths := make([]string, 0, len(paths))
 	for _, p := range paths {
 		// filter unversioned vendor store
-		if filepath.Clean(p) != filepath.Clean(VendorStoreDir) {
+		if filepath.Clean(p) != filepath.Clean(VendorStoreDir(usrMountpoint)) {
 			retPaths = append(retPaths, p)
 		}
 	}

--- a/internal/torcx/store_test.go
+++ b/internal/torcx/store_test.go
@@ -37,14 +37,14 @@ func TestFilterStoreVersion(t *testing.T) {
 		},
 		{
 			"matching version",
-			[]string{VendorStoreDir},
+			[]string{VendorStoreDir(VendorUsrDir)},
 			"1.0.0",
 			"1.0.0",
-			[]string{VendorStoreDir},
+			[]string{VendorStoreDir(VendorUsrDir)},
 		},
 		{
 			"non-matching version",
-			[]string{VendorStoreDir},
+			[]string{VendorStoreDir(VendorUsrDir)},
 			"1.0.0",
 			"2.0.0",
 			[]string{},
@@ -61,7 +61,7 @@ func TestFilterStoreVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Logf("Checking %q", tt.desc)
 
-		res := FilterStoreVersions(tt.stores, tt.curVersion, tt.filterVersion)
+		res := FilterStoreVersions(VendorUsrDir, tt.stores, tt.curVersion, tt.filterVersion)
 		if !reflect.DeepEqual(res, tt.resultStore) {
 			t.Fatalf("expected %#v, got %#v", tt.resultStore, res)
 		}

--- a/internal/torcx/types.go
+++ b/internal/torcx/types.go
@@ -47,6 +47,7 @@ type ConfigV0 struct {
 type CommonConfig struct {
 	BaseDir    string   `json:"base_dir,omitempty"`
 	RunDir     string   `json:"run_dir,omitempty"`
+	UsrDir     string   `json:"usr_dir,omitempty"`
 	ConfDir    string   `json:"conf_dir,omitempty"`
 	StorePaths []string `json:"store_paths,omitempty"`
 }
@@ -291,8 +292,8 @@ func RemoteVersionFromJSONV1(j RemoteVersionV1) RemoteVersion {
 	remoteVer := RemoteVersion{
 		format:   j.Format,
 		hash:     j.Hash,
-		version:  j.Version,
 		location: j.Location,
+		version:  j.Version,
 	}
 	return remoteVer
 }


### PR DESCRIPTION
This updates common CLI logic so that the USR mountpoint (usually at
`/usr`) can be adjusted at runtime via the `TORCX_USR_MOUNTPOINT`
environment flag.