### PR TITLE
vendor: bump x/crypto to latest

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4ebe51236d69c62027d0f3a53a86af21002a8276a8c2a3b261d5306bf9d9aaac
-updated: 2018-05-14T14:36:59.663592638Z
+hash: 88fb3ea06466db07f3998bbd639e43353d1a8466a1295cbb959f7dce0f7133f9
+updated: 2018-06-21T12:20:25.313537496Z
 imports:
 - name: github.com/euank/gotmpl
   version: ed7fb72c02be28d65699e5fbfa6ddf8ee2d88f9a
@@ -19,7 +19,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/magiconair/properties
-  version: 2c9e9502788518c97fe44e8955cd069417ee89df
+  version: c2353362d570a7bfa228149c62842019201cfb71
 - name: github.com/mitchellh/mapstructure
   version: bb74f1db0675b241733089d5a1faa5dd8b0ef57b
 - name: github.com/northbright/ctx
@@ -29,7 +29,7 @@ imports:
 - name: github.com/opencontainers/go-digest
   version: 279bed98673dd5bef374d3b6e4b09e2af76183bf
 - name: github.com/pelletier/go-toml
-  version: 66540cf1fcd2c3aee6f6787dfa32a6ae9a870f12
+  version: c01d1270ff3e442a8a57cddc1c92dc1138598194
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/sirupsen/logrus
@@ -37,7 +37,7 @@ imports:
   subpackages:
   - hooks/syslog
 - name: github.com/spf13/afero
-  version: 63644898a8da0bc22138abf860edaf5277b6102e
+  version: 787d034dfe70e44075ccc060d346146ef53270ad
   subpackages:
   - mem
 - name: github.com/spf13/cast
@@ -51,7 +51,7 @@ imports:
 - name: github.com/spf13/viper
   version: 7538d73b4eb9511d85a9f1dfef202eeb8ac260f4
 - name: golang.org/x/crypto
-  version: d6449816ce06963d9d136eee5a56fca5b0616e7e
+  version: 7f39a6fea4fe9364fb61e1def6a268a51b4f3a06
   subpackages:
   - cast5
   - openpgp
@@ -72,7 +72,7 @@ imports:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877
+  version: 5cec4b58c438bd98288aeb248bab2c1840713d21
   subpackages:
   - transform
   - unicode/norm

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,7 +19,7 @@ import:
   subpackages:
   - ctxcopy
 - package: golang.org/x/crypto
-  version: d6449816ce06963d9d136eee5a56fca5b0616e7e
+  version: 7f39a6fea4fe9364fb61e1def6a268a51b4f3a06 
   subpackages:
   - openpgp
   - openpgp/clearsign

--- a/vendor/github.com/magiconair/properties/decode.go
+++ b/vendor/github.com/magiconair/properties/decode.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Frank Schroeder. All rights reserved.
+// Copyright 2018 Frank Schroeder. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/magiconair/properties/doc.go
+++ b/vendor/github.com/magiconair/properties/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Frank Schroeder. All rights reserved.
+// Copyright 2018 Frank Schroeder. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -73,7 +73,7 @@
 //   # refers to the users' home dir
 //   home = ${HOME}
 //
-//   # local key takes precendence over env var: u = foo
+//   # local key takes precedence over env var: u = foo
 //   USER = foo
 //   u = ${USER}
 //
@@ -102,7 +102,7 @@
 //   v = p.GetString("key", "def")
 //   v = p.GetDuration("key", 999)
 //
-// As an alterantive properties may be applied with the standard
+// As an alternative properties may be applied with the standard
 // library's flag implementation at any time.
 //
 //   # Standard configuration

--- a/vendor/github.com/magiconair/properties/integrate.go
+++ b/vendor/github.com/magiconair/properties/integrate.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Frank Schroeder. All rights reserved.
+// Copyright 2018 Frank Schroeder. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/magiconair/properties/lex.go
+++ b/vendor/github.com/magiconair/properties/lex.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Frank Schroeder. All rights reserved.
+// Copyright 2018 Frank Schroeder. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 //

--- a/vendor/github.com/magiconair/properties/load.go
+++ b/vendor/github.com/magiconair/properties/load.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Frank Schroeder. All rights reserved.
+// Copyright 2018 Frank Schroeder. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -16,21 +16,157 @@ import (
 type Encoding uint
 
 const (
+	// utf8Default is a private placeholder for the zero value of Encoding to
+	// ensure that it has the correct meaning. UTF8 is the default encoding but
+	// was assigned a non-zero value which cannot be changed without breaking
+	// existing code. Clients should continue to use the public constants.
+	utf8Default Encoding = iota
+
 	// UTF8 interprets the input data as UTF-8.
-	UTF8 Encoding = 1 << iota
+	UTF8
 
 	// ISO_8859_1 interprets the input data as ISO-8859-1.
 	ISO_8859_1
 )
 
+type Loader struct {
+	// Encoding determines how the data from files and byte buffers
+	// is interpreted. For URLs the Content-Type header is used
+	// to determine the encoding of the data.
+	Encoding Encoding
+
+	// DisableExpansion configures the property expansion of the
+	// returned property object. When set to true, the property values
+	// will not be expanded and the Property object will not be checked
+	// for invalid expansion expressions.
+	DisableExpansion bool
+
+	// IgnoreMissing configures whether missing files or URLs which return
+	// 404 are reported as errors. When set to true, missing files and 404
+	// status codes are not reported as errors.
+	IgnoreMissing bool
+}
+
+// Load reads a buffer into a Properties struct.
+func (l *Loader) LoadBytes(buf []byte) (*Properties, error) {
+	return l.loadBytes(buf, l.Encoding)
+}
+
+// LoadAll reads the content of multiple URLs or files in the given order into
+// a Properties struct. If IgnoreMissing is true then a 404 status code or
+// missing file will not be reported as error. Encoding sets the encoding for
+// files. For the URLs see LoadURL for the Content-Type header and the
+// encoding.
+func (l *Loader) LoadAll(names []string) (*Properties, error) {
+	all := NewProperties()
+	for _, name := range names {
+		n, err := expandName(name)
+		if err != nil {
+			return nil, err
+		}
+
+		var p *Properties
+		switch {
+		case strings.HasPrefix(n, "http://"):
+			p, err = l.LoadURL(n)
+		case strings.HasPrefix(n, "https://"):
+			p, err = l.LoadURL(n)
+		default:
+			p, err = l.LoadFile(n)
+		}
+		if err != nil {
+			return nil, err
+		}
+		all.Merge(p)
+	}
+
+	all.DisableExpansion = l.DisableExpansion
+	if all.DisableExpansion {
+		return all, nil
+	}
+	return all, all.check()
+}
+
+// LoadFile reads a file into a Properties struct.
+// If IgnoreMissing is true then a missing file will not be
+// reported as error.
+func (l *Loader) LoadFile(filename string) (*Properties, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		if l.IgnoreMissing && os.IsNotExist(err) {
+			LogPrintf("properties: %s not found. skipping", filename)
+			return NewProperties(), nil
+		}
+		return nil, err
+	}
+	return l.loadBytes(data, l.Encoding)
+}
+
+// LoadURL reads the content of the URL into a Properties struct.
+//
+// The encoding is determined via the Content-Type header which
+// should be set to 'text/plain'. If the 'charset' parameter is
+// missing, 'iso-8859-1' or 'latin1' the encoding is set to
+// ISO-8859-1. If the 'charset' parameter is set to 'utf-8' the
+// encoding is set to UTF-8. A missing content type header is
+// interpreted as 'text/plain; charset=utf-8'.
+func (l *Loader) LoadURL(url string) (*Properties, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("properties: error fetching %q. %s", url, err)
+	}
+
+	if resp.StatusCode == 404 && l.IgnoreMissing {
+		LogPrintf("properties: %s returned %d. skipping", url, resp.StatusCode)
+		return NewProperties(), nil
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("properties: %s returned %d", url, resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("properties: %s error reading response. %s", url, err)
+	}
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	var enc Encoding
+	switch strings.ToLower(ct) {
+	case "text/plain", "text/plain; charset=iso-8859-1", "text/plain; charset=latin1":
+		enc = ISO_8859_1
+	case "", "text/plain; charset=utf-8":
+		enc = UTF8
+	default:
+		return nil, fmt.Errorf("properties: invalid content type %s", ct)
+	}
+
+	return l.loadBytes(body, enc)
+}
+
+func (l *Loader) loadBytes(buf []byte, enc Encoding) (*Properties, error) {
+	p, err := parse(convert(buf, enc))
+	if err != nil {
+		return nil, err
+	}
+	p.DisableExpansion = l.DisableExpansion
+	if p.DisableExpansion {
+		return p, nil
+	}
+	return p, p.check()
+}
+
 // Load reads a buffer into a Properties struct.
 func Load(buf []byte, enc Encoding) (*Properties, error) {
-	return loadBuf(buf, enc)
+	l := &Loader{Encoding: enc}
+	return l.LoadBytes(buf)
 }
 
 // LoadString reads an UTF8 string into a properties struct.
 func LoadString(s string) (*Properties, error) {
-	return loadBuf([]byte(s), UTF8)
+	l := &Loader{Encoding: UTF8}
+	return l.LoadBytes([]byte(s))
 }
 
 // LoadMap creates a new Properties struct from a string map.
@@ -44,34 +180,32 @@ func LoadMap(m map[string]string) *Properties {
 
 // LoadFile reads a file into a Properties struct.
 func LoadFile(filename string, enc Encoding) (*Properties, error) {
-	return loadAll([]string{filename}, enc, false)
+	l := &Loader{Encoding: enc}
+	return l.LoadAll([]string{filename})
 }
 
 // LoadFiles reads multiple files in the given order into
 // a Properties struct. If 'ignoreMissing' is true then
 // non-existent files will not be reported as error.
 func LoadFiles(filenames []string, enc Encoding, ignoreMissing bool) (*Properties, error) {
-	return loadAll(filenames, enc, ignoreMissing)
+	l := &Loader{Encoding: enc, IgnoreMissing: ignoreMissing}
+	return l.LoadAll(filenames)
 }
 
 // LoadURL reads the content of the URL into a Properties struct.
-//
-// The encoding is determined via the Content-Type header which
-// should be set to 'text/plain'. If the 'charset' parameter is
-// missing, 'iso-8859-1' or 'latin1' the encoding is set to
-// ISO-8859-1. If the 'charset' parameter is set to 'utf-8' the
-// encoding is set to UTF-8. A missing content type header is
-// interpreted as 'text/plain; charset=utf-8'.
+// See Loader#LoadURL for details.
 func LoadURL(url string) (*Properties, error) {
-	return loadAll([]string{url}, UTF8, false)
+	l := &Loader{Encoding: UTF8}
+	return l.LoadAll([]string{url})
 }
 
 // LoadURLs reads the content of multiple URLs in the given order into a
-// Properties struct. If 'ignoreMissing' is true then a 404 status code will
-// not be reported as error. See LoadURL for the Content-Type header
+// Properties struct. If IgnoreMissing is true then a 404 status code will
+// not be reported as error. See Loader#LoadURL for the Content-Type header
 // and the encoding.
 func LoadURLs(urls []string, ignoreMissing bool) (*Properties, error) {
-	return loadAll(urls, UTF8, ignoreMissing)
+	l := &Loader{Encoding: UTF8, IgnoreMissing: ignoreMissing}
+	return l.LoadAll(urls)
 }
 
 // LoadAll reads the content of multiple URLs or files in the given order into a
@@ -79,7 +213,8 @@ func LoadURLs(urls []string, ignoreMissing bool) (*Properties, error) {
 // not be reported as error. Encoding sets the encoding for files. For the URLs please see
 // LoadURL for the Content-Type header and the encoding.
 func LoadAll(names []string, enc Encoding, ignoreMissing bool) (*Properties, error) {
-	return loadAll(names, enc, ignoreMissing)
+	l := &Loader{Encoding: enc, IgnoreMissing: ignoreMissing}
+	return l.LoadAll(names)
 }
 
 // MustLoadString reads an UTF8 string into a Properties struct and
@@ -122,90 +257,6 @@ func MustLoadAll(names []string, enc Encoding, ignoreMissing bool) *Properties {
 	return must(LoadAll(names, enc, ignoreMissing))
 }
 
-func loadBuf(buf []byte, enc Encoding) (*Properties, error) {
-	p, err := parse(convert(buf, enc))
-	if err != nil {
-		return nil, err
-	}
-	return p, p.check()
-}
-
-func loadAll(names []string, enc Encoding, ignoreMissing bool) (*Properties, error) {
-	result := NewProperties()
-	for _, name := range names {
-		n, err := expandName(name)
-		if err != nil {
-			return nil, err
-		}
-		var p *Properties
-		if strings.HasPrefix(n, "http://") || strings.HasPrefix(n, "https://") {
-			p, err = loadURL(n, ignoreMissing)
-		} else {
-			p, err = loadFile(n, enc, ignoreMissing)
-		}
-		if err != nil {
-			return nil, err
-		}
-		result.Merge(p)
-
-	}
-	return result, result.check()
-}
-
-func loadFile(filename string, enc Encoding, ignoreMissing bool) (*Properties, error) {
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		if ignoreMissing && os.IsNotExist(err) {
-			LogPrintf("properties: %s not found. skipping", filename)
-			return NewProperties(), nil
-		}
-		return nil, err
-	}
-	p, err := parse(convert(data, enc))
-	if err != nil {
-		return nil, err
-	}
-	return p, nil
-}
-
-func loadURL(url string, ignoreMissing bool) (*Properties, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("properties: error fetching %q. %s", url, err)
-	}
-	if resp.StatusCode == 404 && ignoreMissing {
-		LogPrintf("properties: %s returned %d. skipping", url, resp.StatusCode)
-		return NewProperties(), nil
-	}
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("properties: %s returned %d", url, resp.StatusCode)
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("properties: %s error reading response. %s", url, err)
-	}
-	if err = resp.Body.Close(); err != nil {
-		return nil, fmt.Errorf("properties: %s error reading response. %s", url, err)
-	}
-
-	ct := resp.Header.Get("Content-Type")
-	var enc Encoding
-	switch strings.ToLower(ct) {
-	case "text/plain", "text/plain; charset=iso-8859-1", "text/plain; charset=latin1":
-		enc = ISO_8859_1
-	case "", "text/plain; charset=utf-8":
-		enc = UTF8
-	default:
-		return nil, fmt.Errorf("properties: invalid content type %s", ct)
-	}
-
-	p, err := parse(convert(body, enc))
-	if err != nil {
-		return nil, err
-	}
-	return p, nil
-}
-
 func must(p *Properties, err error) *Properties {
 	if err != nil {
 		ErrorHandler(err)
@@ -226,7 +277,7 @@ func expandName(name string) (string, error) {
 // first 256 unicode code points cover ISO-8859-1.
 func convert(buf []byte, enc Encoding) string {
 	switch enc {
-	case UTF8:
+	case utf8Default, UTF8:
 		return string(buf)
 	case ISO_8859_1:
 		runes := make([]rune, len(buf))

--- a/vendor/github.com/magiconair/properties/parser.go
+++ b/vendor/github.com/magiconair/properties/parser.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Frank Schroeder. All rights reserved.
+// Copyright 2018 Frank Schroeder. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/magiconair/properties/properties.go
+++ b/vendor/github.com/magiconair/properties/properties.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Frank Schroeder. All rights reserved.
+// Copyright 2018 Frank Schroeder. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -81,6 +81,17 @@ func NewProperties() *Properties {
 		c:       map[string][]string{},
 		k:       []string{},
 	}
+}
+
+// Load reads a buffer into the given Properties struct.
+func (p *Properties) Load(buf []byte, enc Encoding) error {
+	l := &Loader{Encoding: enc, DisableExpansion: p.DisableExpansion}
+	newProperties, err := l.LoadBytes(buf)
+	if err != nil {
+		return err
+	}
+	p.Merge(newProperties)
+	return nil
 }
 
 // Get returns the expanded value for the given key if exists.

--- a/vendor/github.com/magiconair/properties/rangecheck.go
+++ b/vendor/github.com/magiconair/properties/rangecheck.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Frank Schroeder. All rights reserved.
+// Copyright 2018 Frank Schroeder. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/pelletier/go-toml/marshal.go
+++ b/vendor/github.com/pelletier/go-toml/marshal.go
@@ -11,10 +11,13 @@ import (
 	"time"
 )
 
+const tagKeyMultiline = "multiline"
+
 type tomlOpts struct {
 	name      string
 	comment   string
 	commented bool
+	multiline bool
 	include   bool
 	omitempty bool
 }
@@ -230,7 +233,12 @@ func (e *Encoder) valueToTree(mtype reflect.Type, mval reflect.Value) (*Tree, er
 				if err != nil {
 					return nil, err
 				}
-				tval.SetWithComment(opts.name, opts.comment, opts.commented, val)
+
+				tval.SetWithOptions(opts.name, SetOptions{
+					Comment:   opts.comment,
+					Commented: opts.commented,
+					Multiline: opts.multiline,
+				}, val)
 			}
 		}
 	case reflect.Map:
@@ -559,7 +567,8 @@ func tomlOptions(vf reflect.StructField) tomlOpts {
 		comment = c
 	}
 	commented, _ := strconv.ParseBool(vf.Tag.Get("commented"))
-	result := tomlOpts{name: vf.Name, comment: comment, commented: commented, include: true, omitempty: false}
+	multiline, _ := strconv.ParseBool(vf.Tag.Get(tagKeyMultiline))
+	result := tomlOpts{name: vf.Name, comment: comment, commented: commented, multiline: multiline, include: true, omitempty: false}
 	if parse[0] != "" {
 		if parse[0] == "-" && len(parse) == 1 {
 			result.include = false

--- a/vendor/github.com/pelletier/go-toml/tomltree_write.go
+++ b/vendor/github.com/pelletier/go-toml/tomltree_write.go
@@ -12,7 +12,41 @@ import (
 	"time"
 )
 
-// encodes a string to a TOML-compliant string value
+// Encodes a string to a TOML-compliant multi-line string value
+// This function is a clone of the existing encodeTomlString function, except that whitespace characters
+// are preserved. Quotation marks and backslashes are also not escaped.
+func encodeMultilineTomlString(value string) string {
+	var b bytes.Buffer
+
+	for _, rr := range value {
+		switch rr {
+		case '\b':
+			b.WriteString(`\b`)
+		case '\t':
+			b.WriteString("\t")
+		case '\n':
+			b.WriteString("\n")
+		case '\f':
+			b.WriteString(`\f`)
+		case '\r':
+			b.WriteString("\r")
+		case '"':
+			b.WriteString(`"`)
+		case '\\':
+			b.WriteString(`\`)
+		default:
+			intRr := uint16(rr)
+			if intRr < 0x001F {
+				b.WriteString(fmt.Sprintf("\\u%0.4X", intRr))
+			} else {
+				b.WriteRune(rr)
+			}
+		}
+	}
+	return b.String()
+}
+
+// Encodes a string to a TOML-compliant string value
 func encodeTomlString(value string) string {
 	var b bytes.Buffer
 
@@ -45,6 +79,15 @@ func encodeTomlString(value string) string {
 }
 
 func tomlValueStringRepresentation(v interface{}, indent string, arraysOneElementPerLine bool) (string, error) {
+	// this interface check is added to dereference the change made in the writeTo function.
+	// That change was made to allow this function to see formatting options.
+	tv, ok := v.(*tomlValue)
+	if ok {
+		v = tv.value
+	} else {
+		tv = &tomlValue{}
+	}
+
 	switch value := v.(type) {
 	case uint64:
 		return strconv.FormatUint(value, 10), nil
@@ -58,6 +101,9 @@ func tomlValueStringRepresentation(v interface{}, indent string, arraysOneElemen
 		}
 		return strings.ToLower(strconv.FormatFloat(value, 'f', -1, 32)), nil
 	case string:
+		if tv.multiline {
+			return "\"\"\"\n" + encodeMultilineTomlString(value) + "\"\"\"", nil
+		}
 		return "\"" + encodeTomlString(value) + "\"", nil
 	case []byte:
 		b, _ := v.([]byte)
@@ -130,7 +176,7 @@ func (t *Tree) writeTo(w io.Writer, indent, keyspace string, bytesCount int64, a
 			return bytesCount, fmt.Errorf("invalid value type at %s: %T", k, t.values[k])
 		}
 
-		repr, err := tomlValueStringRepresentation(v.value, indent, arraysOneElementPerLine)
+		repr, err := tomlValueStringRepresentation(v, indent, arraysOneElementPerLine)
 		if err != nil {
 			return bytesCount, err
 		}

--- a/vendor/github.com/spf13/afero/mem/file.go
+++ b/vendor/github.com/spf13/afero/mem/file.go
@@ -131,6 +131,9 @@ func (f *File) Sync() error {
 }
 
 func (f *File) Readdir(count int) (res []os.FileInfo, err error) {
+	if !f.fileData.dir {
+		return nil, &os.PathError{Op: "readdir", Path: f.fileData.name, Err: errors.New("not a dir")}
+	}
 	var outLength int64
 
 	f.fileData.Lock()

--- a/vendor/golang.org/x/crypto/openpgp/keys.go
+++ b/vendor/golang.org/x/crypto/openpgp/keys.go
@@ -346,22 +346,25 @@ EachPacket:
 
 		switch pkt := p.(type) {
 		case *packet.UserId:
+			// Make a new Identity object, that we might wind up throwing away.
+			// We'll only add it if we get a valid self-signature over this
+			// userID.
 			current = new(Identity)
 			current.Name = pkt.Id
 			current.UserId = pkt
-			e.Identities[pkt.Id] = current
 
 			for {
 				p, err = packets.Next()
 				if err == io.EOF {
-					return nil, io.ErrUnexpectedEOF
+					break EachPacket
 				} else if err != nil {
 					return nil, err
 				}
 
 				sig, ok := p.(*packet.Signature)
 				if !ok {
-					return nil, errors.StructuralError("user ID packet not followed by self-signature")
+					packets.Unread(p)
+					continue EachPacket
 				}
 
 				if (sig.SigType == packet.SigTypePositiveCert || sig.SigType == packet.SigTypeGenericCert) && sig.IssuerKeyId != nil && *sig.IssuerKeyId == e.PrimaryKey.KeyId {
@@ -369,9 +372,10 @@ EachPacket:
 						return nil, errors.StructuralError("user ID self-signature invalid: " + err.Error())
 					}
 					current.SelfSignature = sig
-					break
+					e.Identities[pkt.Id] = current
+				} else {
+					current.Signatures = append(current.Signatures, sig)
 				}
-				current.Signatures = append(current.Signatures, sig)
 			}
 		case *packet.Signature:
 			if pkt.SigType == packet.SigTypeKeyRevocation {
@@ -500,6 +504,10 @@ func NewEntity(name, comment, email string, config *packet.Config) (*Entity, err
 			IssuerKeyId:  &e.PrimaryKey.KeyId,
 		},
 	}
+	err = e.Identities[uid.Id].SelfSignature.SignUserId(uid.Id, e.PrimaryKey, e.PrivateKey, config)
+	if err != nil {
+		return nil, err
+	}
 
 	// If the user passes in a DefaultHash via packet.Config,
 	// set the PreferredHash for the SelfSignature.
@@ -529,13 +537,16 @@ func NewEntity(name, comment, email string, config *packet.Config) (*Entity, err
 	}
 	e.Subkeys[0].PublicKey.IsSubkey = true
 	e.Subkeys[0].PrivateKey.IsSubkey = true
-
+	err = e.Subkeys[0].Sig.SignKey(e.Subkeys[0].PublicKey, e.PrivateKey, config)
+	if err != nil {
+		return nil, err
+	}
 	return e, nil
 }
 
-// SerializePrivate serializes an Entity, including private key material, to
-// the given Writer. For now, it must only be used on an Entity returned from
-// NewEntity.
+// SerializePrivate serializes an Entity, including private key material, but
+// excluding signatures from other entities, to the given Writer.
+// Identities and subkeys are re-signed in case they changed since NewEntry.
 // If config is nil, sensible defaults will be used.
 func (e *Entity) SerializePrivate(w io.Writer, config *packet.Config) (err error) {
 	err = e.PrivateKey.Serialize(w)
@@ -573,8 +584,8 @@ func (e *Entity) SerializePrivate(w io.Writer, config *packet.Config) (err error
 	return nil
 }
 
-// Serialize writes the public part of the given Entity to w. (No private
-// key material will be output).
+// Serialize writes the public part of the given Entity to w, including
+// signatures from other entities. No private key material will be output.
 func (e *Entity) Serialize(w io.Writer) error {
 	err := e.PrimaryKey.Serialize(w)
 	if err != nil {


### PR DESCRIPTION
This is to hopefully fix buggy parsing of public keys, see
https://github.com/golang/go/issues/25850
