### PR TITLE
docs: fix several mistakes

### DIFF
--- a/Documentation/design/remotes.md
+++ b/Documentation/design/remotes.md
@@ -41,14 +41,14 @@ Schema:
 -   value (object, required)
     -   base\_url (string, required)
     -   keys (array, required, fixed-type, not-nil) - (object)
-        -   armored_keyring (string)
+        -   armored\_keyring (string)
 
 Entries:
 -   `kind`: hardcoded to `remote-manifest-v0` for this schema revision. The type+version of this JSON manifest.
 -   `value`: object containing a single typed key-value. Manifest content.
 -   `value/base_url`: template with base URL for the remote. Supported protocols: "http", "https".
 -   `value/keys/#`: array of single-type objects, arbitrary length. It contains trusted keys for signature verification.
--   `value/keys/#/armored_keyring`: path to an ASCII-armored OpenPGP keyring, relative to `base_url`.
+-   `value/keys/#/armored_keyring`: path to an ASCII-armored OpenPGP keyring, relative to the directory where this configuration is located.
 
 URL template is evaluated for simple variable substitution. Interpolated variables are:
  * `${COREOS_BOARD}`: board type (e.g. "amd64-usr")
@@ -105,9 +105,9 @@ Each remote has a specific base URL, which can be templated and locally reified 
 ### Serving a remote
 
 The entrypoint to a remote is its signed manifest. From a configured node, it can be located as follows:
- `manifest_url: ${base_url}/torcx_manifest.json.asc`
+ `manifest_url: ${base_url}/torcx_remote_contents.json.asc`
 
-Where `base_url` is the reified base URL of the remote, and `torcx_manifest.json.asc` is a fixed-name file containing an armor-signed JSON manifest of remote contents.
+Where `base_url` is the reified base URL of the remote, and `torcx_remote_contents.json.asc` is a fixed-name file containing a clear-signed JSON manifest of remote contents.
 
 A remote will typically contain multiple manifests, one per each supported OS board+version combination.
 
@@ -116,7 +116,7 @@ A remote will typically contain multiple manifests, one per each supported OS bo
 This is loosely based on the tectonic-torcx package list, which currently looks like https://tectonic-torcx.release.core-os.net/manifests/amd64-usr/1520.5.0/torcx_manifest.json
 
 Notable changes are:
- * manifest filename is now `torcx_manifest.json.asc`
+ * manifest filename is now `torcx_remote_contents.json.asc`
  * JSON content is now wrapped with an OpenPGP armored signature
  * s/packages/images/ (i.e. avoid "package" terminology, and align with other manifests)
  * `kind`: `torcx-remote-contents-v1`

--- a/Documentation/schemas/remote-contents-v1.md
+++ b/Documentation/schemas/remote-contents-v1.md
@@ -9,7 +9,7 @@ This is loosely based on the tectonic-torcx package list v0, which does not have
 
 Notable changes in v1 are:
  * JSON schema specification
- * manifest filename is now `torcx_manifest.json.asc`
+ * manifest filename is now `torcx_remote_contents.json.asc`
  * JSON content is now wrapped with an OpenPGP armored signature
  * more consistent use of "image" terminology
  * `kind` is no `torcx-remote-contents-v1`
@@ -17,7 +17,7 @@ Notable changes in v1 are:
 
 ## Manifest location and signature
 
-A remote contents manifest for a specific remote can be located by looking for a file called `torcx_manifest.json.asc` under the resolved remote `${base_url}`.
+A remote contents manifest for a specific remote can be located by looking for a file called `torcx_remote_contents.json.asc` under the resolved remote `${base_url}`.
 
 This file contains a JSON object (schema described below), wrapped in an OpenPGP armored clearsign signature.
 

--- a/Documentation/schemas/remote-manifest-v0.md
+++ b/Documentation/schemas/remote-manifest-v0.md
@@ -1,13 +1,14 @@
 # Remote Manifest - v0
 
 The configuration for a remote, locally stored on a node.
+This is stored in a file called `remote.json` and located within a directory with the same name as the Torcx remote name.
 
 ## Schema
 - kind (string, required)
 - value (object, required)
-  - base_url (string, required)
+  - base\_url (string, required)
   - keys (array, required, fixed-type, not-nil) - (object)
-    - armored_keyring (string)
+    - armored\_keyring (string)
 
 ## Entries
 
@@ -15,7 +16,7 @@ The configuration for a remote, locally stored on a node.
 - `value`: object containing a single typed key-value. Manifest content.
 - `value/base_url`: template with base URL for the remote. Supported protocols: "http", "https", "file".
 - `value/keys/#`: array of single-type objects, arbitrary length. It contains trusted keys for signature verification.
-- `value/keys/#/armored_keyring`: path to an ASCII-armored OpenPGP keyring, relative to `base_url`.
+- `value/keys/#/armored_keyring`: path to an ASCII-armored OpenPGP keyring, relative to the directory containing this remote manifest.
 
 NOTE: `file://` URLs should generally only be used by offline remotes distributed as part of `/usr`, and controlled by the OS vendor.
 


### PR DESCRIPTION
This fixes several errors in the doc-reference with the actual
implementation, and clarifies locations and filenames.