### PR TITLE
docs: fix README link

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -2,4 +2,4 @@
 
 This directory contains developer documentation and design documents ("devdocs") for Torcx.
 
-User documentation is provided separately at https://github.com/coreos/docs/tree/master/torcx.
+User documentation is provided separately at https://github.com/coreos/docs/tree/master/os.


### PR DESCRIPTION
This updates the user-docs link in README.

Fixes: https://github.com/coreos/torcx/issues/126