### PR TITLE
remote: allow plaintext HTTP in base URLs

### DIFF
--- a/internal/torcx/remote.go
+++ b/internal/torcx/remote.go
@@ -256,7 +256,7 @@ func NewRemotesCache(ctx context.Context, usrMountpoint string, baseDirs []strin
 		}
 		var manifest string
 		switch url.Scheme {
-		case "https":
+		case "https", "http":
 			tries := 0
 			for {
 				tries++


### PR DESCRIPTION
This allows torcx remotes to be served over plaintext HTTP.